### PR TITLE
refactor: extract RestSource engine into muralis-source-common

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,61 @@
+# Muralis Context
+
+Domain and architecture language for muralis — a Wayland wallpaper manager that searches remote **Sources**, favorites images, and rotates them via a display **Backend**.
+
+## Language
+
+### Sources
+
+**Source**:
+A provider of wallpapers, implementing the `WallpaperSource` trait (`search`, `download`, `resolve_url`).
+_Avoid_: provider, plugin (reserve "plugin" for the crate, not the running object)
+
+**RestSource**:
+The single concrete `WallpaperSource` for paged JSON REST APIs (wallhaven, unsplash, pexels), configured by a **Source Descriptor**. Owns auth, request building, pagination, **page-filling**, JSON parsing, and error context — the per-source crate supplies only response structs and their mapping to **Preview**. Lives in the `muralis-source-common` crate, not core.
+_Avoid_: ApiClient, RestClient, HttpSource
+
+**muralis-source-common**:
+The crate holding **RestSource**, **HttpFetch**, **Source Descriptor**, and the `SearchResponse`/`DetailResponse` traits. Depends on `muralis-core`; the wallhaven/unsplash/pexels crates depend on it.
+
+**Source Descriptor**:
+The per-source data a **RestSource** is built from: auth strategy, search/detail endpoint paths, upstream page cap, URL→id parser, block size B, and the response→**Preview** mapping.
+_Avoid_: config (that is the user's TOML), spec
+
+**Feed Source**:
+The non-REST **Source** backed by RSS/Atom; not a **RestSource** (no paged JSON API, fetches image dimensions itself).
+
+### Search & paging
+
+**Preview**:
+A transient search result (`WallpaperPreview`) — not yet favorited, not on disk.
+_Avoid_: result, thumbnail, image
+
+**Page-filling**:
+A **RestSource** consuming a fixed block of B upstream API pages for one logical page, applying the aspect filter as it goes, returning up to `per_page` matches. Best-effort *within the block*: a logical page may return fewer than `per_page` even when more matches exist upstream.
+_Avoid_: over-fetch, pagination
+
+**Block (B)**:
+The fixed number of upstream API pages a **RestSource** maps to one logical page. Logical page N covers upstream pages `(N-1)*B+1 .. N*B`. Per-source in the **Source Descriptor**. Server-filtering sources (wallhaven) use B=1; post-filtered sources use B>1.
+
+### Transport
+
+**HttpFetch**:
+The transport seam behind **RestSource**, at bytes level: `get(url, headers, query) -> (StatusCode, Bytes)`. Lives in `muralis-source-common`. The real adapter wraps `reqwest`; the test adapter returns canned bytes and asserts the auth header and pagination params. Auth injection and JSON parsing live in **RestSource**, not behind this seam.
+_Avoid_: HttpClient, Transport, Fetcher
+
+## Relationships
+
+- A **RestSource** is built from exactly one **Source Descriptor** and one **HttpFetch** adapter.
+- A **RestSource** produces zero or more **Previews** per logical page via **Page-filling** over a **Block** of upstream pages.
+- The **Feed Source** is a **Source** but never a **RestSource**.
+- The `SourceRegistry` holds **Sources** (any mix of **RestSource** and **Feed Source**).
+
+## Example dialogue
+
+> **Dev:** "When the GUI asks the **RestSource** for page 2 at 21:9, does it resume where page 1 stopped?"
+> **Maintainer:** "No — paging is stateless. Page 2 is the next **Block** of upstream pages. **Page-filling** runs inside that block; if only three match, you get three. We accept the leak — the grid is infinite-scroll, not random-access. A logical page that returns zero matches is the CLI's end-of-results signal; `search` still returns a plain `Vec`."
+
+## Flagged ambiguities
+
+- "filter" was used for both the user's aspect choice and the act of discarding non-matching **Previews** — resolved: the choice is `AspectRatioFilter`; the act is part of **Page-filling**.
+- aspect filtering previously lived in the CLI caller (`main.rs:230`); it now lives in each **Source**: **RestSource** filters via **Page-filling**, and the **Feed Source** filters after resolving dimensions. The CLI no longer post-filters at all — every **Source** honors the aspect contract itself.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1667,6 +1667,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "muralis-source-common"
+version = "0.2.4"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "muralis-core",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "muralis-source-feed"
 version = "0.2.4"
 dependencies = [
@@ -1687,12 +1700,12 @@ dependencies = [
 name = "muralis-source-pexels"
 version = "0.2.4"
 dependencies = [
- "async-trait",
- "bytes",
  "muralis-core",
+ "muralis-source-common",
  "reqwest",
  "serde",
  "serde_json",
+ "tokio",
  "toml",
 ]
 
@@ -1700,12 +1713,12 @@ dependencies = [
 name = "muralis-source-unsplash"
 version = "0.2.4"
 dependencies = [
- "async-trait",
- "bytes",
  "muralis-core",
+ "muralis-source-common",
  "reqwest",
  "serde",
  "serde_json",
+ "tokio",
  "toml",
 ]
 
@@ -1713,12 +1726,12 @@ dependencies = [
 name = "muralis-source-wallhaven"
 version = "0.2.4"
 dependencies = [
- "async-trait",
- "bytes",
  "muralis-core",
+ "muralis-source-common",
  "reqwest",
  "serde",
  "serde_json",
+ "tokio",
  "toml",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "muralis-core",
     "muralis-daemon",
     "muralis-cli",
+    "muralis-source-common",
     "muralis-source-wallhaven",
     "muralis-source-unsplash",
     "muralis-source-pexels",

--- a/muralis-cli/src/main.rs
+++ b/muralis-cli/src/main.rs
@@ -227,11 +227,8 @@ async fn main() -> Result<()> {
             for src in &sources {
                 match src.search(&query, page, per_page, aspect).await {
                     Ok(previews) => {
+                        // Sources honor the aspect filter themselves now.
                         for p in previews {
-                            // Client-side aspect filter for sources that don't support it natively
-                            if !aspect.matches(p.width, p.height) {
-                                continue;
-                            }
                             let is_favorited = db
                                 .is_favorited_by_source(p.source_type.as_str(), &p.source_id)
                                 .unwrap_or(false);

--- a/muralis-core/src/error.rs
+++ b/muralis-core/src/error.rs
@@ -26,8 +26,12 @@ pub enum MuralisError {
     #[error("source not configured: {0}")]
     SourceNotConfigured(String),
 
-    #[error("source error: {0}")]
-    Source(String),
+    #[error("{source_type} {op}: {kind}")]
+    Source {
+        source_type: String,
+        op: String,
+        kind: String,
+    },
 
     #[error("wallpaper not found: {0}")]
     WallpaperNotFound(String),

--- a/muralis-core/src/sources/mod.rs
+++ b/muralis-core/src/sources/mod.rs
@@ -123,6 +123,14 @@ pub trait WallpaperSource: Send + Sync {
     fn name(&self) -> &str;
     /// DB type string (e.g. "wallhaven", "feed")
     fn source_type(&self) -> &str;
+
+    /// Return up to `per_page` previews for logical `page`, each matching
+    /// `aspect` (sources MUST honor the aspect filter themselves — callers do
+    /// not post-filter). `per_page` is a best-effort target, not a guarantee:
+    /// a page may return fewer matches even when more exist upstream, because
+    /// filtering happens within a bounded block of upstream pages (see the
+    /// `Block` / page-filling design in `muralis-source-common`). An empty
+    /// result is the caller's end-of-results signal.
     async fn search(
         &self,
         query: &str,

--- a/muralis-source-common/Cargo.toml
+++ b/muralis-source-common/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
-name = "muralis-source-unsplash"
+name = "muralis-source-common"
 edition.workspace = true
 version.workspace = true
 license.workspace = true
 
 [dependencies]
 muralis-core = { path = "../muralis-core" }
-muralis-source-common = { path = "../muralis-source-common" }
+async-trait = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
-toml = { workspace = true }
+serde_json = { workspace = true }
+bytes = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }
-serde_json = { workspace = true }

--- a/muralis-source-common/src/lib.rs
+++ b/muralis-source-common/src/lib.rs
@@ -1,0 +1,550 @@
+//! Shared engine for paged JSON REST wallpaper sources.
+//!
+//! `RestSource` is the single concrete [`WallpaperSource`] for paged JSON REST
+//! APIs (wallhaven, unsplash, pexels). It owns auth injection, request building,
+//! pagination, page-filling, JSON parsing, and error context. Per-source crates
+//! supply only their response structs and the mapping to `WallpaperPreview` via
+//! the [`SearchResponse`] / [`DetailResponse`] traits. See `CONTEXT.md`.
+
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use reqwest::StatusCode;
+use serde::de::DeserializeOwned;
+
+use muralis_core::error::{MuralisError, Result};
+use muralis_core::models::WallpaperPreview;
+use muralis_core::sources::{AspectRatioFilter, WallpaperSource};
+
+pub mod testing;
+
+/// Bytes-level transport seam. The real adapter wraps `reqwest`; tests use a
+/// canned stub. Auth injection and JSON parsing live in `RestSource`, not here.
+#[async_trait]
+pub trait HttpFetch: Send + Sync {
+    async fn get(
+        &self,
+        url: &str,
+        headers: &[(&str, &str)],
+        query: &[(&str, &str)],
+    ) -> Result<(StatusCode, bytes::Bytes)>;
+}
+
+/// Production [`HttpFetch`] backed by `reqwest`. The only code that touches the
+/// HTTP client directly.
+pub struct ReqwestFetch(pub reqwest::Client);
+
+#[async_trait]
+impl HttpFetch for ReqwestFetch {
+    async fn get(
+        &self,
+        url: &str,
+        headers: &[(&str, &str)],
+        query: &[(&str, &str)],
+    ) -> Result<(StatusCode, bytes::Bytes)> {
+        let mut req = self.0.get(url).query(query);
+        for (name, value) in headers {
+            req = req.header(*name, *value);
+        }
+        let resp = req.send().await?;
+        let status = resp.status();
+        let bytes = resp.bytes().await?;
+        Ok((status, bytes))
+    }
+}
+
+/// Where a source's credential goes.
+pub enum Auth {
+    /// Appended to the query string, e.g. wallhaven `?apikey=…`.
+    QueryParam {
+        key: &'static str,
+        value: Option<String>,
+    },
+    /// Sent as a header, e.g. unsplash `Authorization: Client-ID …`.
+    Header {
+        name: &'static str,
+        value: String,
+    },
+    None,
+}
+
+/// Per-source data a [`RestSource`] is built from. No behaviour beyond the
+/// mappers carried by the response traits.
+pub struct Descriptor {
+    pub source_type: &'static str,
+    pub display_name: &'static str,
+    pub base: &'static str,
+    pub auth: Auth,
+    pub search_path: &'static str,
+    pub detail_path: &'static str,
+    /// Query key for the search term: `"q"` (wallhaven) or `"query"`.
+    pub query_key: &'static str,
+    /// Query key for page size, or `None` when the API has no such param
+    /// (wallhaven uses a fixed server page size).
+    pub per_page_param: Option<&'static str>,
+    /// Value sent for `per_page_param` — the upstream page size.
+    pub per_page_cap: u32,
+    /// Number of upstream pages mapped to one logical page (Block B).
+    pub block: u32,
+    /// Extra constant query params (categories/purity, orientation=landscape).
+    pub extra_query: Vec<(&'static str, String)>,
+    /// When `Some(key)`, the server filters by aspect via this query param
+    /// (wallhaven `ratios`); client-side filtering is then skipped.
+    pub server_aspect_param: Option<&'static str>,
+}
+
+/// A source's search-response envelope.
+pub trait SearchResponse: DeserializeOwned + Send {
+    fn into_previews(self, source_type: &str) -> Vec<WallpaperPreview>;
+}
+
+/// A source's detail-response envelope (sometimes the bare item).
+pub trait DetailResponse: DeserializeOwned + Send {
+    fn into_preview(self, source_type: &str) -> WallpaperPreview;
+    /// Parse this source's wallpaper id out of a page URL, or `None` if the
+    /// URL doesn't belong to this source.
+    fn parse_id(url: &str) -> Option<String>;
+}
+
+/// The deep module: a full [`WallpaperSource`] for paged JSON REST APIs.
+pub struct RestSource<S, D> {
+    desc: Descriptor,
+    http: Arc<dyn HttpFetch>,
+    _marker: PhantomData<fn() -> (S, D)>,
+}
+
+impl<S, D> RestSource<S, D> {
+    pub fn new(desc: Descriptor, http: Arc<dyn HttpFetch>) -> Self {
+        Self {
+            desc,
+            http,
+            _marker: PhantomData,
+        }
+    }
+}
+
+#[async_trait]
+impl<S, D> WallpaperSource for RestSource<S, D>
+where
+    S: SearchResponse + 'static,
+    D: DetailResponse + 'static,
+{
+    fn name(&self) -> &str {
+        self.desc.display_name
+    }
+
+    fn source_type(&self) -> &str {
+        self.desc.source_type
+    }
+
+    async fn search(
+        &self,
+        query: &str,
+        page: u32,
+        per_page: u32,
+        aspect: AspectRatioFilter,
+    ) -> Result<Vec<WallpaperPreview>> {
+        let page = page.max(1);
+        let block = self.desc.block.max(1);
+        let first = (page - 1) * block + 1;
+        let last = page * block;
+        let url = format!("{}{}", self.desc.base, self.desc.search_path);
+        // Server filters by aspect for some sources; only then skip client filter.
+        let server_ratio = self
+            .desc
+            .server_aspect_param
+            .and_then(|param| aspect.to_wallhaven_ratio().map(|r| (param, r)));
+        let client_filter = self.desc.server_aspect_param.is_none();
+
+        let mut out: Vec<WallpaperPreview> = Vec::new();
+        for upstream in first..=last {
+            let upstream_s = upstream.to_string();
+            let cap_s = self.desc.per_page_cap.to_string();
+
+            let mut query_params: Vec<(&str, &str)> =
+                vec![(self.desc.query_key, query), ("page", &upstream_s)];
+            if let Some(pp) = self.desc.per_page_param {
+                query_params.push((pp, &cap_s));
+            }
+            for (k, v) in &self.desc.extra_query {
+                query_params.push((k, v.as_str()));
+            }
+            if let Some((param, ratio)) = server_ratio {
+                query_params.push((param, ratio));
+            }
+
+            let mut headers: Vec<(&str, &str)> = Vec::new();
+            match &self.desc.auth {
+                Auth::QueryParam {
+                    key,
+                    value: Some(v),
+                } => query_params.push((key, v.as_str())),
+                Auth::Header { name, value } => headers.push((name, value.as_str())),
+                _ => {}
+            }
+
+            let (status, bytes) = self.http.get(&url, &headers, &query_params).await?;
+            if !status.is_success() {
+                return Err(self.err(
+                    "search",
+                    &format!("{query:?} p{upstream}"),
+                    status.as_u16().to_string(),
+                ));
+            }
+            let resp: S = serde_json::from_slice(&bytes).map_err(|e| {
+                self.err(
+                    "search",
+                    &format!("{query:?} p{upstream}"),
+                    format!("decode: {e}"),
+                )
+            })?;
+
+            for preview in resp.into_previews(self.desc.source_type) {
+                if client_filter && !aspect.matches(preview.width, preview.height) {
+                    continue;
+                }
+                out.push(preview);
+                if out.len() as u32 >= per_page {
+                    return Ok(out);
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    async fn resolve_url(&self, url: &str) -> Result<Option<WallpaperPreview>> {
+        let Some(id) = D::parse_id(url) else {
+            return Ok(None);
+        };
+        let endpoint = format!("{}{}/{}", self.desc.base, self.desc.detail_path, id);
+
+        let mut headers: Vec<(&str, &str)> = Vec::new();
+        let mut query_params: Vec<(&str, &str)> = Vec::new();
+        match &self.desc.auth {
+            Auth::QueryParam {
+                key,
+                value: Some(v),
+            } => query_params.push((key, v.as_str())),
+            Auth::Header { name, value } => headers.push((name, value.as_str())),
+            _ => {}
+        }
+
+        let (status, bytes) = self.http.get(&endpoint, &headers, &query_params).await?;
+        if !status.is_success() {
+            return Err(self.err("resolve", &endpoint, status.as_u16().to_string()));
+        }
+        let resp: D = serde_json::from_slice(&bytes)
+            .map_err(|e| self.err("resolve", &endpoint, format!("decode: {e}")))?;
+        Ok(Some(resp.into_preview(self.desc.source_type)))
+    }
+
+    async fn download(&self, preview: &WallpaperPreview) -> Result<bytes::Bytes> {
+        let (status, bytes) = self.http.get(&preview.full_url, &[], &[]).await?;
+        if !status.is_success() {
+            return Err(self.err("download", &preview.full_url, status.as_u16().to_string()));
+        }
+        Ok(bytes)
+    }
+}
+
+impl<S, D> RestSource<S, D> {
+    fn err(&self, op: &str, detail: &str, kind: String) -> MuralisError {
+        MuralisError::Source {
+            source_type: self.desc.source_type.to_string(),
+            op: format!("{op} {detail}"),
+            kind,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::StubFetch;
+    use muralis_core::models::SourceType;
+    use serde::Deserialize;
+
+    // -- fixture source: response shape `{"items":[{"id","w","h"}]}` --
+
+    #[derive(Deserialize)]
+    struct FixSearch {
+        items: Vec<FixItem>,
+    }
+    #[derive(Deserialize)]
+    struct FixItem {
+        id: String,
+        w: u32,
+        h: u32,
+    }
+
+    impl SearchResponse for FixSearch {
+        fn into_previews(self, source_type: &str) -> Vec<WallpaperPreview> {
+            self.items
+                .into_iter()
+                .map(|i| WallpaperPreview {
+                    source_type: SourceType::new(source_type),
+                    source_id: i.id.clone(),
+                    source_url: format!("https://fix.test/{}", i.id),
+                    thumbnail_url: format!("https://fix.test/{}/thumb", i.id),
+                    full_url: format!("https://fix.test/{}/full", i.id),
+                    width: i.w,
+                    height: i.h,
+                    tags: Vec::new(),
+                })
+                .collect()
+        }
+    }
+
+    impl DetailResponse for FixItem {
+        fn into_preview(self, source_type: &str) -> WallpaperPreview {
+            FixSearch { items: vec![self] }
+                .into_previews(source_type)
+                .pop()
+                .unwrap()
+        }
+        fn parse_id(url: &str) -> Option<String> {
+            url.strip_prefix("https://fix.test/")
+                .map(|r| r.trim_end_matches('/').to_string())
+        }
+    }
+
+    fn descriptor() -> Descriptor {
+        Descriptor {
+            source_type: "fix",
+            display_name: "Fixture",
+            base: "https://api.fix.test",
+            auth: Auth::None,
+            search_path: "/search",
+            detail_path: "/photo",
+            query_key: "query",
+            per_page_param: Some("per_page"),
+            per_page_cap: 30,
+            block: 1,
+            extra_query: Vec::new(),
+            server_aspect_param: None,
+        }
+    }
+
+    fn source(desc: Descriptor, http: StubFetch) -> RestSource<FixSearch, FixItem> {
+        RestSource::new(desc, Arc::new(http))
+    }
+
+    #[tokio::test]
+    async fn search_maps_response_to_previews() {
+        let body = r#"{"items":[{"id":"a1","w":3840,"h":2160}]}"#;
+        let src = source(descriptor(), StubFetch::ok(body));
+
+        let previews = src
+            .search("trees", 1, 24, AspectRatioFilter::All)
+            .await
+            .unwrap();
+
+        assert_eq!(previews.len(), 1);
+        assert_eq!(previews[0].source_id, "a1");
+        assert_eq!(previews[0].source_type, SourceType::new("fix"));
+        assert_eq!(previews[0].width, 3840);
+    }
+
+    #[tokio::test]
+    async fn search_sends_query_page_and_per_page() {
+        let http = Arc::new(StubFetch::ok(r#"{"items":[]}"#));
+        let src: RestSource<FixSearch, FixItem> = RestSource::new(descriptor(), http.clone());
+
+        src.search("cats", 1, 24, AspectRatioFilter::All)
+            .await
+            .unwrap();
+
+        let call = http.last_call();
+        assert_eq!(call.url, "https://api.fix.test/search");
+        assert_eq!(call.query_value("query"), Some("cats"));
+        assert_eq!(call.query_value("page"), Some("1"));
+        assert_eq!(call.query_value("per_page"), Some("30")); // the cap
+    }
+
+    #[tokio::test]
+    async fn auth_query_param_goes_in_query() {
+        let mut desc = descriptor();
+        desc.auth = Auth::QueryParam {
+            key: "apikey",
+            value: Some("secret".into()),
+        };
+        let http = Arc::new(StubFetch::ok(r#"{"items":[]}"#));
+        let src: RestSource<FixSearch, FixItem> = RestSource::new(desc, http.clone());
+
+        src.search("x", 1, 24, AspectRatioFilter::All)
+            .await
+            .unwrap();
+
+        assert_eq!(http.last_call().query_value("apikey"), Some("secret"));
+    }
+
+    #[tokio::test]
+    async fn auth_header_goes_in_headers() {
+        let mut desc = descriptor();
+        desc.auth = Auth::Header {
+            name: "Authorization",
+            value: "Client-ID k".into(),
+        };
+        let http = Arc::new(StubFetch::ok(r#"{"items":[]}"#));
+        let src: RestSource<FixSearch, FixItem> = RestSource::new(desc, http.clone());
+
+        src.search("x", 1, 24, AspectRatioFilter::All)
+            .await
+            .unwrap();
+
+        let call = http.last_call();
+        assert_eq!(call.header_value("Authorization"), Some("Client-ID k"));
+        assert_eq!(call.query_value("apikey"), None);
+    }
+
+    #[tokio::test]
+    async fn logical_page_maps_to_block_of_upstream_pages() {
+        let mut desc = descriptor();
+        desc.block = 3;
+        let http = Arc::new(StubFetch::ok_pages(&[
+            r#"{"items":[]}"#,
+            r#"{"items":[]}"#,
+            r#"{"items":[]}"#,
+        ]));
+        let src: RestSource<FixSearch, FixItem> = RestSource::new(desc, http.clone());
+
+        // logical page 2, block 3 -> upstream pages 4,5,6
+        src.search("x", 2, 100, AspectRatioFilter::All)
+            .await
+            .unwrap();
+
+        let pages: Vec<_> = http
+            .calls()
+            .iter()
+            .map(|c| c.query_value("page").unwrap().to_string())
+            .collect();
+        assert_eq!(pages, vec!["4", "5", "6"]);
+    }
+
+    #[tokio::test]
+    async fn page_filling_filters_by_aspect_and_caps_at_per_page() {
+        // 21:9 ultrawide = 2560x1080; 16:9 = 1920x1080 (filtered out at 21:9)
+        let mut desc = descriptor();
+        desc.block = 2;
+        let wide = r#"{"items":[{"id":"w1","w":2560,"h":1080},{"id":"n1","w":1920,"h":1080},{"id":"w2","w":2560,"h":1080}]}"#;
+        let http = Arc::new(StubFetch::ok_pages(&[wide, wide]));
+        let src: RestSource<FixSearch, FixItem> = RestSource::new(desc, http.clone());
+
+        let previews = src
+            .search("x", 1, 3, AspectRatioFilter::Ratio21x9)
+            .await
+            .unwrap();
+
+        // only the 21:9 items survive; capped at per_page=3
+        assert_eq!(previews.len(), 3);
+        assert!(previews.iter().all(|p| p.source_id.starts_with('w')));
+    }
+
+    #[tokio::test]
+    async fn page_filling_stops_at_block_edge_even_if_short() {
+        let mut desc = descriptor();
+        desc.block = 1; // one upstream page only
+        let only_narrow = r#"{"items":[{"id":"n1","w":1920,"h":1080}]}"#;
+        let http = Arc::new(StubFetch::ok(only_narrow));
+        let src: RestSource<FixSearch, FixItem> = RestSource::new(desc, http);
+
+        let previews = src
+            .search("x", 1, 10, AspectRatioFilter::Ratio21x9)
+            .await
+            .unwrap();
+
+        // wanted 10, block exhausted with 0 matches -> empty, no further fetch
+        assert!(previews.is_empty());
+    }
+
+    #[tokio::test]
+    async fn server_aspect_emits_ratio_param_and_skips_client_filter() {
+        let mut desc = descriptor();
+        desc.server_aspect_param = Some("ratios");
+        // a 16:9 item is returned but client filter is OFF, so it survives a 21:9 query
+        let body = r#"{"items":[{"id":"s1","w":1920,"h":1080}]}"#;
+        let http = Arc::new(StubFetch::ok(body));
+        let src: RestSource<FixSearch, FixItem> = RestSource::new(desc, http.clone());
+
+        let previews = src
+            .search("x", 1, 24, AspectRatioFilter::Ratio21x9)
+            .await
+            .unwrap();
+
+        assert_eq!(http.last_call().query_value("ratios"), Some("21x9"));
+        assert_eq!(previews.len(), 1); // not client-filtered
+    }
+
+    #[tokio::test]
+    async fn non_success_status_yields_source_error_with_context() {
+        let src = source(descriptor(), StubFetch::status(429));
+
+        let err = src
+            .search("trees", 2, 24, AspectRatioFilter::All)
+            .await
+            .unwrap_err();
+
+        match err {
+            MuralisError::Source {
+                source_type,
+                op,
+                kind,
+            } => {
+                assert_eq!(source_type, "fix");
+                assert!(op.contains("trees"), "op was {op:?}");
+                assert!(op.contains("p2"), "op was {op:?}"); // logical p2, block 1 -> upstream p2
+                assert_eq!(kind, "429");
+            }
+            other => panic!("expected Source error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_url_parses_id_fetches_detail_and_maps() {
+        let body = r#"{"id":"d9","w":3000,"h":2000}"#;
+        let http = Arc::new(StubFetch::ok(body));
+        let src: RestSource<FixSearch, FixItem> = RestSource::new(descriptor(), http.clone());
+
+        let preview = src
+            .resolve_url("https://fix.test/d9")
+            .await
+            .unwrap()
+            .expect("should resolve");
+
+        assert_eq!(preview.source_id, "d9");
+        assert_eq!(http.last_call().url, "https://api.fix.test/photo/d9");
+    }
+
+    #[tokio::test]
+    async fn resolve_url_returns_none_for_foreign_url() {
+        let http = Arc::new(StubFetch::ok(r#"{"id":"x","w":1,"h":1}"#));
+        let src: RestSource<FixSearch, FixItem> = RestSource::new(descriptor(), http.clone());
+
+        let resolved = src.resolve_url("https://other.example/p/1").await.unwrap();
+
+        assert!(resolved.is_none());
+        assert!(http.calls().is_empty(), "should not hit the network");
+    }
+
+    #[tokio::test]
+    async fn download_fetches_full_url_bytes() {
+        let http = Arc::new(StubFetch::ok("IMGDATA"));
+        let src: RestSource<FixSearch, FixItem> = RestSource::new(descriptor(), http.clone());
+        let preview = WallpaperPreview {
+            source_type: SourceType::new("fix"),
+            source_id: "a".into(),
+            source_url: "https://fix.test/a".into(),
+            thumbnail_url: "t".into(),
+            full_url: "https://cdn.fix.test/a.jpg".into(),
+            width: 1,
+            height: 1,
+            tags: Vec::new(),
+        };
+
+        let bytes = src.download(&preview).await.unwrap();
+
+        assert_eq!(&bytes[..], b"IMGDATA");
+        assert_eq!(http.last_call().url, "https://cdn.fix.test/a.jpg");
+    }
+}

--- a/muralis-source-common/src/lib.rs
+++ b/muralis-source-common/src/lib.rs
@@ -154,7 +154,7 @@ where
         let server_ratio = self
             .desc
             .server_aspect_param
-            .and_then(|param| aspect.to_wallhaven_ratio().map(|r| (param, r)));
+            .zip(aspect.to_wallhaven_ratio());
         let client_filter = self.desc.server_aspect_param.is_none();
 
         let mut out: Vec<WallpaperPreview> = Vec::new();

--- a/muralis-source-common/src/testing.rs
+++ b/muralis-source-common/src/testing.rs
@@ -1,0 +1,112 @@
+//! Test support: a canned [`HttpFetch`] that records calls and replays
+//! fixed responses. Available to downstream source crates for their tests.
+
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use reqwest::StatusCode;
+
+use muralis_core::error::Result;
+
+use crate::HttpFetch;
+
+/// One captured request.
+#[derive(Clone, Debug)]
+pub struct RecordedCall {
+    pub url: String,
+    pub headers: Vec<(String, String)>,
+    pub query: Vec<(String, String)>,
+}
+
+impl RecordedCall {
+    /// Value of the first query param matching `key`, if any.
+    pub fn query_value(&self, key: &str) -> Option<&str> {
+        self.query
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.as_str())
+    }
+
+    /// Value of the first header matching `name`, if any.
+    pub fn header_value(&self, name: &str) -> Option<&str> {
+        self.headers
+            .iter()
+            .find(|(k, _)| k == name)
+            .map(|(_, v)| v.as_str())
+    }
+}
+
+/// Replays `responses` in order (clamping to the last once exhausted) and
+/// records every call for assertions.
+pub struct StubFetch {
+    responses: Vec<(StatusCode, bytes::Bytes)>,
+    calls: Mutex<Vec<RecordedCall>>,
+    next: Mutex<usize>,
+}
+
+impl StubFetch {
+    pub fn new(responses: Vec<(StatusCode, bytes::Bytes)>) -> Self {
+        Self {
+            responses,
+            calls: Mutex::new(Vec::new()),
+            next: Mutex::new(0),
+        }
+    }
+
+    /// A single `200 OK` JSON body.
+    pub fn ok(body: &str) -> Self {
+        Self::new(vec![(StatusCode::OK, bytes::Bytes::from(body.to_string()))])
+    }
+
+    /// A sequence of `200 OK` JSON bodies, one per upstream page.
+    pub fn ok_pages(bodies: &[&str]) -> Self {
+        Self::new(
+            bodies
+                .iter()
+                .map(|b| (StatusCode::OK, bytes::Bytes::from(b.to_string())))
+                .collect(),
+        )
+    }
+
+    /// A single non-success status with an empty body.
+    pub fn status(code: u16) -> Self {
+        Self::new(vec![(
+            StatusCode::from_u16(code).unwrap(),
+            bytes::Bytes::new(),
+        )])
+    }
+
+    pub fn calls(&self) -> Vec<RecordedCall> {
+        self.calls.lock().unwrap().clone()
+    }
+
+    pub fn last_call(&self) -> RecordedCall {
+        self.calls().last().expect("no calls recorded").clone()
+    }
+}
+
+#[async_trait]
+impl HttpFetch for StubFetch {
+    async fn get(
+        &self,
+        url: &str,
+        headers: &[(&str, &str)],
+        query: &[(&str, &str)],
+    ) -> Result<(StatusCode, bytes::Bytes)> {
+        self.calls.lock().unwrap().push(RecordedCall {
+            url: url.to_string(),
+            headers: headers
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+            query: query
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+        });
+        let mut next = self.next.lock().unwrap();
+        let i = (*next).min(self.responses.len().saturating_sub(1));
+        *next += 1;
+        Ok(self.responses[i].clone())
+    }
+}

--- a/muralis-source-feed/src/lib.rs
+++ b/muralis-source-feed/src/lib.rs
@@ -77,7 +77,7 @@ impl WallpaperSource for FeedSource {
         _query: &str,
         _page: u32,
         _per_page: u32,
-        _aspect: AspectRatioFilter,
+        aspect: AspectRatioFilter,
     ) -> Result<Vec<WallpaperPreview>> {
         let body = self
             .client
@@ -87,7 +87,11 @@ impl WallpaperSource for FeedSource {
             .bytes()
             .await?;
         let feed = feed_rs::parser::parse(&body[..]).map_err(|e| {
-            muralis_core::error::MuralisError::Source(format!("feed parse error: {e}"))
+            muralis_core::error::MuralisError::Source {
+                source_type: "feed".into(),
+                op: "parse".into(),
+                kind: e.to_string(),
+            }
         })?;
 
         let mut previews = Vec::new();
@@ -146,6 +150,10 @@ impl WallpaperSource for FeedSource {
                 }
             }
         }
+
+        // Honor the aspect contract once dimensions are known (matches() keeps
+        // entries whose size is still unknown).
+        previews.retain(|p| aspect.matches(p.width, p.height));
 
         Ok(previews)
     }

--- a/muralis-source-pexels/Cargo.toml
+++ b/muralis-source-pexels/Cargo.toml
@@ -6,9 +6,11 @@ license.workspace = true
 
 [dependencies]
 muralis-core = { path = "../muralis-core" }
-async-trait = { workspace = true }
+muralis-source-common = { path = "../muralis-source-common" }
 reqwest = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
-bytes = { workspace = true }
 toml = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }
+serde_json = { workspace = true }

--- a/muralis-source-pexels/src/lib.rs
+++ b/muralis-source-pexels/src/lib.rs
@@ -1,11 +1,17 @@
-use async_trait::async_trait;
+use std::sync::Arc;
+
 use serde::Deserialize;
 
-use muralis_core::error::Result;
 use muralis_core::models::{SourceType, WallpaperPreview};
-use muralis_core::sources::{AspectRatioFilter, WallpaperSource};
+use muralis_core::sources::WallpaperSource;
+use muralis_source_common::{
+    Auth, Descriptor, DetailResponse, ReqwestFetch, RestSource, SearchResponse,
+};
 
 const API_BASE: &str = "https://api.pexels.com/v1";
+/// Upstream pages consumed per logical page — Pexels is client-filtered by
+/// aspect, so over-fetch a few pages to fill a logical page.
+const BLOCK: u32 = 3;
 
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(default)]
@@ -28,128 +34,40 @@ pub fn create_sources(
     let Some(key) = config.api_key else {
         return Vec::new();
     };
-    vec![Box::new(PexelsClient {
-        api_key: key,
-        client,
-    })]
-}
 
-pub struct PexelsClient {
-    api_key: String,
-    client: reqwest::Client,
-}
+    let desc = Descriptor {
+        source_type: "pexels",
+        display_name: "Pexels",
+        base: API_BASE,
+        auth: Auth::Header {
+            name: "Authorization",
+            value: key,
+        },
+        search_path: "/search",
+        detail_path: "/photos",
+        query_key: "query",
+        per_page_param: Some("per_page"),
+        per_page_cap: 80,
+        block: BLOCK,
+        extra_query: vec![("orientation", "landscape".into())],
+        server_aspect_param: None, // filtered client-side
+    };
 
-#[async_trait]
-impl WallpaperSource for PexelsClient {
-    fn name(&self) -> &str {
-        "Pexels"
-    }
-
-    fn source_type(&self) -> &str {
-        "pexels"
-    }
-
-    async fn search(
-        &self,
-        query: &str,
-        page: u32,
-        per_page: u32,
-        _aspect: AspectRatioFilter,
-    ) -> Result<Vec<WallpaperPreview>> {
-        let clamped = per_page.min(80);
-        let resp: PexelsSearchResponse = self
-            .client
-            .get(format!("{API_BASE}/search"))
-            .header("Authorization", &self.api_key)
-            .query(&[
-                ("query", query),
-                ("page", &page.to_string()),
-                ("per_page", &clamped.to_string()),
-                ("orientation", "landscape"),
-            ])
-            .send()
-            .await?
-            .json()
-            .await?;
-
-        let previews = resp
-            .photos
-            .into_iter()
-            .map(|p| {
-                let full_url = p.src.original.clone();
-                WallpaperPreview {
-                    source_type: SourceType::new("pexels"),
-                    source_id: p.id.to_string(),
-                    source_url: p.url,
-                    thumbnail_url: p.src.medium,
-                    full_url,
-                    width: p.width,
-                    height: p.height,
-                    tags: Vec::new(),
-                }
-            })
-            .collect();
-        Ok(previews)
-    }
-
-    async fn resolve_url(&self, url: &str) -> Result<Option<WallpaperPreview>> {
-        // Match pexels.com/photo/<slug>-<id>/
-        let id = if url.contains("pexels.com/photo/") {
-            // Extract trailing numeric ID: pexels.com/photo/some-slug-12345/
-            url.trim_end_matches('/')
-                .rsplit('-')
-                .next()
-                .and_then(|s| s.parse::<u64>().ok())
-        } else {
-            None
-        };
-
-        let Some(id) = id else {
-            return Ok(None);
-        };
-
-        let resp: PexelsPhoto = self
-            .client
-            .get(format!("{API_BASE}/photos/{id}"))
-            .header("Authorization", &self.api_key)
-            .send()
-            .await?
-            .json()
-            .await?;
-
-        Ok(Some(WallpaperPreview {
-            source_type: SourceType::new("pexels"),
-            source_id: resp.id.to_string(),
-            source_url: resp.url,
-            thumbnail_url: resp.src.medium,
-            full_url: resp.src.original,
-            width: resp.width,
-            height: resp.height,
-            tags: Vec::new(),
-        }))
-    }
-
-    async fn download(&self, preview: &WallpaperPreview) -> Result<bytes::Bytes> {
-        let bytes = self
-            .client
-            .get(&preview.full_url)
-            .send()
-            .await?
-            .bytes()
-            .await?;
-        Ok(bytes)
-    }
+    let http = Arc::new(ReqwestFetch(client));
+    vec![Box::new(
+        RestSource::<PexelsSearchResponse, PexelsPhoto>::new(desc, http),
+    )]
 }
 
 // -- API response types --
 
 #[derive(Debug, Deserialize)]
-struct PexelsSearchResponse {
+pub struct PexelsSearchResponse {
     photos: Vec<PexelsPhoto>,
 }
 
 #[derive(Debug, Deserialize)]
-struct PexelsPhoto {
+pub struct PexelsPhoto {
     id: u64,
     width: u32,
     height: u32,
@@ -163,69 +81,128 @@ struct PexelsSrc {
     medium: String,
 }
 
+impl SearchResponse for PexelsSearchResponse {
+    fn into_previews(self, source_type: &str) -> Vec<WallpaperPreview> {
+        self.photos
+            .into_iter()
+            .map(|p| p.into_preview(source_type))
+            .collect()
+    }
+}
+
+impl DetailResponse for PexelsPhoto {
+    fn into_preview(self, source_type: &str) -> WallpaperPreview {
+        WallpaperPreview {
+            source_type: SourceType::new(source_type),
+            source_id: self.id.to_string(),
+            source_url: self.url,
+            thumbnail_url: self.src.medium,
+            full_url: self.src.original,
+            width: self.width,
+            height: self.height,
+            tags: Vec::new(), // Pexels has no tags
+        }
+    }
+
+    fn parse_id(url: &str) -> Option<String> {
+        if !url.contains("pexels.com/photo/") {
+            return None;
+        }
+        // pexels.com/photo/some-slug-12345/  ->  12345
+        url.trim_end_matches('/')
+            .rsplit('-')
+            .next()
+            .and_then(|s| s.parse::<u64>().ok())
+            .map(|id| id.to_string())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use muralis_core::sources::AspectRatioFilter;
+    use muralis_source_common::testing::StubFetch;
 
     const MOCK_RESPONSE: &str = r##"{
-        "total_results": 1,
         "page": 1,
-        "per_page": 24,
+        "per_page": 80,
         "photos": [
             {
                 "id": 12345,
                 "width": 4000,
                 "height": 2500,
                 "url": "https://www.pexels.com/photo/12345/",
-                "photographer": "Test",
-                "photographer_url": "",
-                "photographer_id": 1,
-                "avg_color": "#000000",
                 "src": {
                     "original": "https://images.pexels.com/photos/12345/pexels-photo-12345.jpeg",
-                    "large2x": "https://images.pexels.com/photos/12345/pexels-photo-12345.jpeg?w=1880",
-                    "large": "https://images.pexels.com/photos/12345/pexels-photo-12345.jpeg?w=940",
-                    "medium": "https://images.pexels.com/photos/12345/pexels-photo-12345.jpeg?w=350",
-                    "small": "https://images.pexels.com/photos/12345/pexels-photo-12345.jpeg?w=130",
-                    "portrait": "",
-                    "landscape": "",
-                    "tiny": ""
-                },
-                "liked": false,
-                "alt": "Test photo"
+                    "medium": "https://images.pexels.com/photos/12345/pexels-photo-12345.jpeg?w=350"
+                }
             }
         ]
     }"##;
 
-    #[test]
-    fn test_parse_pexels_response() {
-        let resp: PexelsSearchResponse = serde_json::from_str(MOCK_RESPONSE).unwrap();
-        assert_eq!(resp.photos.len(), 1);
-        let p = &resp.photos[0];
-        assert_eq!(p.id, 12345);
-        assert_eq!(p.width, 4000);
+    fn source(http: Arc<StubFetch>) -> RestSource<PexelsSearchResponse, PexelsPhoto> {
+        let desc = Descriptor {
+            source_type: "pexels",
+            display_name: "Pexels",
+            base: API_BASE,
+            auth: Auth::Header {
+                name: "Authorization",
+                value: "RAWKEY".into(),
+            },
+            search_path: "/search",
+            detail_path: "/photos",
+            query_key: "query",
+            per_page_param: Some("per_page"),
+            per_page_cap: 80,
+            block: BLOCK,
+            extra_query: vec![("orientation", "landscape".into())],
+            server_aspect_param: None,
+        };
+        RestSource::new(desc, http)
     }
 
-    #[test]
-    fn test_pexels_to_preview() {
-        let resp: PexelsSearchResponse = serde_json::from_str(MOCK_RESPONSE).unwrap();
-        let previews: Vec<WallpaperPreview> = resp
-            .photos
-            .into_iter()
-            .map(|p| WallpaperPreview {
-                source_type: SourceType::new("pexels"),
-                source_id: p.id.to_string(),
-                source_url: p.url,
-                thumbnail_url: p.src.medium,
-                full_url: p.src.original,
-                width: p.width,
-                height: p.height,
-                tags: Vec::new(),
-            })
-            .collect();
+    #[tokio::test]
+    async fn maps_response_to_preview_with_empty_tags() {
+        let http = Arc::new(StubFetch::ok_pages(&[
+            MOCK_RESPONSE,
+            r#"{"photos":[]}"#,
+            r#"{"photos":[]}"#,
+        ]));
+        let previews = source(http)
+            .search("x", 1, 24, AspectRatioFilter::All)
+            .await
+            .unwrap();
 
         assert_eq!(previews.len(), 1);
         assert_eq!(previews[0].source_id, "12345");
         assert_eq!(previews[0].width, 4000);
+        assert!(previews[0].tags.is_empty());
+    }
+
+    #[tokio::test]
+    async fn search_uses_raw_header_auth_and_per_page_cap() {
+        let http = Arc::new(StubFetch::ok(MOCK_RESPONSE));
+        source(http.clone())
+            .search("waves", 1, 24, AspectRatioFilter::All)
+            .await
+            .unwrap();
+
+        let call = http.last_call();
+        assert_eq!(call.url, "https://api.pexels.com/v1/search");
+        assert_eq!(call.header_value("Authorization"), Some("RAWKEY")); // no prefix
+        assert_eq!(call.query_value("query"), Some("waves"));
+        assert_eq!(call.query_value("per_page"), Some("80"));
+    }
+
+    #[test]
+    fn parses_numeric_id_from_url() {
+        assert_eq!(
+            PexelsPhoto::parse_id("https://www.pexels.com/photo/some-slug-12345/"),
+            Some("12345".into())
+        );
+        assert_eq!(
+            PexelsPhoto::parse_id("https://unsplash.com/photos/abc"),
+            None
+        );
     }
 }

--- a/muralis-source-unsplash/src/lib.rs
+++ b/muralis-source-unsplash/src/lib.rs
@@ -1,11 +1,17 @@
-use async_trait::async_trait;
+use std::sync::Arc;
+
 use serde::Deserialize;
 
-use muralis_core::error::Result;
 use muralis_core::models::{SourceType, WallpaperPreview};
-use muralis_core::sources::{AspectRatioFilter, WallpaperSource};
+use muralis_core::sources::WallpaperSource;
+use muralis_source_common::{
+    Auth, Descriptor, DetailResponse, ReqwestFetch, RestSource, SearchResponse,
+};
 
 const API_BASE: &str = "https://api.unsplash.com";
+/// Upstream pages consumed per logical page — Unsplash is client-filtered by
+/// aspect, so over-fetch a few pages to fill a logical page.
+const BLOCK: u32 = 3;
 
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(default)]
@@ -28,117 +34,40 @@ pub fn create_sources(
     let Some(key) = config.access_key else {
         return Vec::new();
     };
-    vec![Box::new(UnsplashClient {
-        access_key: key,
-        client,
-    })]
-}
 
-pub struct UnsplashClient {
-    access_key: String,
-    client: reqwest::Client,
-}
+    let desc = Descriptor {
+        source_type: "unsplash",
+        display_name: "Unsplash",
+        base: API_BASE,
+        auth: Auth::Header {
+            name: "Authorization",
+            value: format!("Client-ID {key}"),
+        },
+        search_path: "/search/photos",
+        detail_path: "/photos",
+        query_key: "query",
+        per_page_param: Some("per_page"),
+        per_page_cap: 30,
+        block: BLOCK,
+        extra_query: vec![("orientation", "landscape".into())],
+        server_aspect_param: None, // filtered client-side
+    };
 
-#[async_trait]
-impl WallpaperSource for UnsplashClient {
-    fn name(&self) -> &str {
-        "Unsplash"
-    }
-
-    fn source_type(&self) -> &str {
-        "unsplash"
-    }
-
-    async fn search(
-        &self,
-        query: &str,
-        page: u32,
-        per_page: u32,
-        _aspect: AspectRatioFilter,
-    ) -> Result<Vec<WallpaperPreview>> {
-        let clamped = per_page.min(30);
-        let resp: UnsplashSearchResponse = self
-            .client
-            .get(format!("{API_BASE}/search/photos"))
-            .header("Authorization", format!("Client-ID {}", self.access_key))
-            .query(&[
-                ("query", query),
-                ("page", &page.to_string()),
-                ("per_page", &clamped.to_string()),
-                ("orientation", "landscape"),
-            ])
-            .send()
-            .await?
-            .json()
-            .await?;
-
-        let previews = resp
-            .results
-            .into_iter()
-            .map(|p| WallpaperPreview {
-                source_type: SourceType::new("unsplash"),
-                source_id: p.id.clone(),
-                source_url: p.links.html,
-                thumbnail_url: p.urls.regular,
-                full_url: p.urls.raw,
-                width: p.width,
-                height: p.height,
-                tags: p.tags.into_iter().map(|t| t.title).collect(),
-            })
-            .collect();
-        Ok(previews)
-    }
-
-    async fn resolve_url(&self, url: &str) -> Result<Option<WallpaperPreview>> {
-        // Match unsplash.com/photos/<id>
-        let id = if let Some(rest) = url.strip_prefix("https://unsplash.com/photos/") {
-            rest.split('/').next().unwrap_or(rest).trim_end_matches('/')
-        } else {
-            return Ok(None);
-        };
-
-        let resp: UnsplashPhoto = self
-            .client
-            .get(format!("{API_BASE}/photos/{id}"))
-            .header("Authorization", format!("Client-ID {}", self.access_key))
-            .send()
-            .await?
-            .json()
-            .await?;
-
-        Ok(Some(WallpaperPreview {
-            source_type: SourceType::new("unsplash"),
-            source_id: resp.id.clone(),
-            source_url: resp.links.html,
-            thumbnail_url: resp.urls.regular,
-            full_url: resp.urls.raw,
-            width: resp.width,
-            height: resp.height,
-            tags: resp.tags.into_iter().map(|t| t.title).collect(),
-        }))
-    }
-
-    async fn download(&self, preview: &WallpaperPreview) -> Result<bytes::Bytes> {
-        let bytes = self
-            .client
-            .get(&preview.full_url)
-            .send()
-            .await?
-            .bytes()
-            .await?;
-        Ok(bytes)
-    }
+    let http = Arc::new(ReqwestFetch(client));
+    vec![Box::new(
+        RestSource::<UnsplashSearchResponse, UnsplashPhoto>::new(desc, http),
+    )]
 }
 
 // -- API response types --
 
 #[derive(Debug, Deserialize)]
-struct UnsplashSearchResponse {
+pub struct UnsplashSearchResponse {
     results: Vec<UnsplashPhoto>,
 }
 
 #[derive(Debug, Deserialize)]
-struct UnsplashPhoto {
+pub struct UnsplashPhoto {
     id: String,
     width: u32,
     height: u32,
@@ -164,9 +93,46 @@ struct UnsplashTag {
     title: String,
 }
 
+impl SearchResponse for UnsplashSearchResponse {
+    fn into_previews(self, source_type: &str) -> Vec<WallpaperPreview> {
+        self.results
+            .into_iter()
+            .map(|p| p.into_preview(source_type))
+            .collect()
+    }
+}
+
+impl DetailResponse for UnsplashPhoto {
+    fn into_preview(self, source_type: &str) -> WallpaperPreview {
+        WallpaperPreview {
+            source_type: SourceType::new(source_type),
+            source_id: self.id,
+            source_url: self.links.html,
+            thumbnail_url: self.urls.regular,
+            full_url: self.urls.raw,
+            width: self.width,
+            height: self.height,
+            tags: self.tags.into_iter().map(|t| t.title).collect(),
+        }
+    }
+
+    fn parse_id(url: &str) -> Option<String> {
+        let rest = url.strip_prefix("https://unsplash.com/photos/")?;
+        Some(
+            rest.split('/')
+                .next()
+                .unwrap_or(rest)
+                .trim_end_matches('/')
+                .to_string(),
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use muralis_core::sources::AspectRatioFilter;
+    use muralis_source_common::testing::StubFetch;
 
     const MOCK_RESPONSE: &str = r##"{
         "total": 1,
@@ -176,57 +142,85 @@ mod tests {
                 "id": "uns_001",
                 "width": 5000,
                 "height": 3000,
-                "color": "#000000",
                 "urls": {
                     "raw": "https://images.unsplash.com/photo-001",
-                    "full": "https://images.unsplash.com/photo-001?q=100",
-                    "regular": "https://images.unsplash.com/photo-001?w=1080",
-                    "small": "https://images.unsplash.com/photo-001?w=400",
-                    "thumb": "https://images.unsplash.com/photo-001?w=200"
+                    "regular": "https://images.unsplash.com/photo-001?w=1080"
                 },
-                "links": {
-                    "self": "https://api.unsplash.com/photos/uns_001",
-                    "html": "https://unsplash.com/photos/uns_001",
-                    "download": "https://unsplash.com/photos/uns_001/download"
-                },
-                "tags": [
-                    {"title": "mountain"},
-                    {"title": "sky"}
-                ]
+                "links": { "html": "https://unsplash.com/photos/uns_001" },
+                "tags": [ {"title": "mountain"}, {"title": "sky"} ]
             }
         ]
     }"##;
 
-    #[test]
-    fn test_parse_unsplash_response() {
-        let resp: UnsplashSearchResponse = serde_json::from_str(MOCK_RESPONSE).unwrap();
-        assert_eq!(resp.results.len(), 1);
-        let p = &resp.results[0];
-        assert_eq!(p.id, "uns_001");
-        assert_eq!(p.width, 5000);
-        assert_eq!(p.tags.len(), 2);
+    fn source(http: Arc<StubFetch>) -> RestSource<UnsplashSearchResponse, UnsplashPhoto> {
+        let desc = Descriptor {
+            source_type: "unsplash",
+            display_name: "Unsplash",
+            base: API_BASE,
+            auth: Auth::Header {
+                name: "Authorization",
+                value: "Client-ID KEY".into(),
+            },
+            search_path: "/search/photos",
+            detail_path: "/photos",
+            query_key: "query",
+            per_page_param: Some("per_page"),
+            per_page_cap: 30,
+            block: BLOCK,
+            extra_query: vec![("orientation", "landscape".into())],
+            server_aspect_param: None,
+        };
+        RestSource::new(desc, http)
     }
 
-    #[test]
-    fn test_unsplash_to_preview() {
-        let resp: UnsplashSearchResponse = serde_json::from_str(MOCK_RESPONSE).unwrap();
-        let previews: Vec<WallpaperPreview> = resp
-            .results
-            .into_iter()
-            .map(|p| WallpaperPreview {
-                source_type: SourceType::new("unsplash"),
-                source_id: p.id.clone(),
-                source_url: p.links.html,
-                thumbnail_url: p.urls.regular,
-                full_url: p.urls.raw,
-                width: p.width,
-                height: p.height,
-                tags: p.tags.into_iter().map(|t| t.title).collect(),
-            })
-            .collect();
+    #[tokio::test]
+    async fn maps_response_to_preview_with_tags() {
+        // block=3: only the first upstream page has a result.
+        let http = Arc::new(StubFetch::ok_pages(&[
+            MOCK_RESPONSE,
+            r#"{"results":[]}"#,
+            r#"{"results":[]}"#,
+        ]));
+        let previews = source(http)
+            .search("x", 1, 24, AspectRatioFilter::All)
+            .await
+            .unwrap();
 
         assert_eq!(previews.len(), 1);
         assert_eq!(previews[0].source_id, "uns_001");
+        assert_eq!(
+            previews[0].full_url,
+            "https://images.unsplash.com/photo-001"
+        );
         assert_eq!(previews[0].tags, vec!["mountain", "sky"]);
+    }
+
+    #[tokio::test]
+    async fn search_uses_header_auth_query_key_and_per_page() {
+        let http = Arc::new(StubFetch::ok(MOCK_RESPONSE));
+        source(http.clone())
+            .search("birds", 1, 24, AspectRatioFilter::All)
+            .await
+            .unwrap();
+
+        let call = http.last_call();
+        assert_eq!(call.url, "https://api.unsplash.com/search/photos");
+        assert_eq!(call.header_value("Authorization"), Some("Client-ID KEY"));
+        assert_eq!(call.query_value("query"), Some("birds"));
+        assert_eq!(call.query_value("per_page"), Some("30"));
+        assert_eq!(call.query_value("orientation"), Some("landscape"));
+    }
+
+    #[test]
+    fn parses_id_from_url() {
+        assert_eq!(
+            UnsplashPhoto::parse_id("https://unsplash.com/photos/uns_001"),
+            Some("uns_001".into())
+        );
+        assert_eq!(
+            UnsplashPhoto::parse_id("https://unsplash.com/photos/abc/extra"),
+            Some("abc".into())
+        );
+        assert_eq!(UnsplashPhoto::parse_id("https://pexels.com/photo/1"), None);
     }
 }

--- a/muralis-source-wallhaven/Cargo.toml
+++ b/muralis-source-wallhaven/Cargo.toml
@@ -6,9 +6,11 @@ license.workspace = true
 
 [dependencies]
 muralis-core = { path = "../muralis-core" }
-async-trait = { workspace = true }
+muralis-source-common = { path = "../muralis-source-common" }
 reqwest = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
-bytes = { workspace = true }
 toml = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }
+serde_json = { workspace = true }

--- a/muralis-source-wallhaven/src/lib.rs
+++ b/muralis-source-wallhaven/src/lib.rs
@@ -1,9 +1,12 @@
-use async_trait::async_trait;
+use std::sync::Arc;
+
 use serde::Deserialize;
 
-use muralis_core::error::Result;
 use muralis_core::models::{SourceType, WallpaperPreview};
-use muralis_core::sources::{AspectRatioFilter, WallpaperSource};
+use muralis_core::sources::WallpaperSource;
+use muralis_source_common::{
+    Auth, Descriptor, DetailResponse, ReqwestFetch, RestSource, SearchResponse,
+};
 
 const API_BASE: &str = "https://wallhaven.cc/api/v1";
 
@@ -38,114 +41,41 @@ pub fn create_sources(
     if !config.enabled {
         return Vec::new();
     }
-    vec![Box::new(WallhavenClient { config, client })]
-}
 
-pub struct WallhavenClient {
-    config: WallhavenConfig,
-    client: reqwest::Client,
-}
+    let desc = Descriptor {
+        source_type: "wallhaven",
+        display_name: "Wallhaven",
+        base: API_BASE,
+        auth: Auth::QueryParam {
+            key: "apikey",
+            value: config.api_key,
+        },
+        search_path: "/search",
+        detail_path: "/w",
+        query_key: "q",
+        per_page_param: None, // wallhaven uses a fixed server page size
+        per_page_cap: 24,
+        block: 1, // server filters by aspect, so ~every result matches
+        extra_query: vec![("categories", config.categories), ("purity", config.purity)],
+        server_aspect_param: Some("ratios"),
+    };
 
-#[async_trait]
-impl WallpaperSource for WallhavenClient {
-    fn name(&self) -> &str {
-        "Wallhaven"
-    }
-
-    fn source_type(&self) -> &str {
-        "wallhaven"
-    }
-
-    async fn search(
-        &self,
-        query: &str,
-        page: u32,
-        _per_page: u32,
-        aspect: AspectRatioFilter,
-    ) -> Result<Vec<WallpaperPreview>> {
-        let mut req = self.client.get(format!("{API_BASE}/search")).query(&[
-            ("q", query),
-            ("page", &page.to_string()),
-            ("categories", &self.config.categories),
-            ("purity", &self.config.purity),
-        ]);
-
-        if let Some(ref key) = self.config.api_key {
-            req = req.query(&[("apikey", key)]);
-        }
-
-        if let Some(ratio) = aspect.to_wallhaven_ratio() {
-            req = req.query(&[("ratios", ratio)]);
-        }
-
-        let resp: WallhavenResponse = req.send().await?.json().await?;
-        let previews = resp
-            .data
-            .into_iter()
-            .map(|w| WallpaperPreview {
-                source_type: SourceType::new("wallhaven"),
-                source_id: w.id.clone(),
-                source_url: w.url,
-                thumbnail_url: w.thumbs.original,
-                full_url: w.path,
-                width: w.dimension_x,
-                height: w.dimension_y,
-                tags: w.tags.into_iter().map(|t| t.name).collect(),
-            })
-            .collect();
-        Ok(previews)
-    }
-
-    async fn resolve_url(&self, url: &str) -> Result<Option<WallpaperPreview>> {
-        // Match wallhaven.cc/w/<id> or whvn.cc/<id>
-        let id = if let Some(rest) = url.strip_prefix("https://wallhaven.cc/w/") {
-            rest.trim_end_matches('/')
-        } else if let Some(rest) = url.strip_prefix("https://whvn.cc/") {
-            rest.trim_end_matches('/')
-        } else {
-            return Ok(None);
-        };
-
-        let mut req = self.client.get(format!("{API_BASE}/w/{id}"));
-        if let Some(ref key) = self.config.api_key {
-            req = req.query(&[("apikey", key)]);
-        }
-
-        let resp: WallhavenDetailResponse = req.send().await?.json().await?;
-        let w = resp.data;
-        Ok(Some(WallpaperPreview {
-            source_type: SourceType::new("wallhaven"),
-            source_id: w.id.clone(),
-            source_url: w.url,
-            thumbnail_url: w.thumbs.original,
-            full_url: w.path,
-            width: w.dimension_x,
-            height: w.dimension_y,
-            tags: w.tags.into_iter().map(|t| t.name).collect(),
-        }))
-    }
-
-    async fn download(&self, preview: &WallpaperPreview) -> Result<bytes::Bytes> {
-        let bytes = self
-            .client
-            .get(&preview.full_url)
-            .send()
-            .await?
-            .bytes()
-            .await?;
-        Ok(bytes)
-    }
+    let http = Arc::new(ReqwestFetch(client));
+    vec![Box::new(RestSource::<
+        WallhavenResponse,
+        WallhavenDetailResponse,
+    >::new(desc, http))]
 }
 
 // -- API response types --
 
 #[derive(Debug, Deserialize)]
-struct WallhavenResponse {
+pub struct WallhavenResponse {
     data: Vec<WallhavenWallpaper>,
 }
 
 #[derive(Debug, Deserialize)]
-struct WallhavenDetailResponse {
+pub struct WallhavenDetailResponse {
     data: WallhavenWallpaper,
 }
 
@@ -171,82 +101,131 @@ struct WallhavenTag {
     name: String,
 }
 
+impl WallhavenWallpaper {
+    fn into_preview(self, source_type: &str) -> WallpaperPreview {
+        WallpaperPreview {
+            source_type: SourceType::new(source_type),
+            source_id: self.id,
+            source_url: self.url,
+            thumbnail_url: self.thumbs.original,
+            full_url: self.path,
+            width: self.dimension_x,
+            height: self.dimension_y,
+            tags: self.tags.into_iter().map(|t| t.name).collect(),
+        }
+    }
+}
+
+impl SearchResponse for WallhavenResponse {
+    fn into_previews(self, source_type: &str) -> Vec<WallpaperPreview> {
+        self.data
+            .into_iter()
+            .map(|w| w.into_preview(source_type))
+            .collect()
+    }
+}
+
+impl DetailResponse for WallhavenDetailResponse {
+    fn into_preview(self, source_type: &str) -> WallpaperPreview {
+        self.data.into_preview(source_type)
+    }
+
+    fn parse_id(url: &str) -> Option<String> {
+        let rest = url
+            .strip_prefix("https://wallhaven.cc/w/")
+            .or_else(|| url.strip_prefix("https://whvn.cc/"))?;
+        Some(rest.trim_end_matches('/').to_string())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use muralis_core::sources::AspectRatioFilter;
+    use muralis_source_common::testing::StubFetch;
 
     const MOCK_RESPONSE: &str = r##"{
         "data": [
             {
                 "id": "abc123",
                 "url": "https://wallhaven.cc/w/abc123",
-                "short_url": "https://whvn.cc/abc123",
-                "views": 1000,
-                "favorites": 50,
-                "source": "",
-                "purity": "sfw",
-                "category": "general",
                 "dimension_x": 3840,
                 "dimension_y": 2160,
-                "resolution": "3840x2160",
-                "ratio": "1.78",
-                "file_size": 5000000,
-                "file_type": "image/jpeg",
-                "created_at": "2024-01-01 00:00:00",
-                "colors": ["#000000"],
                 "path": "https://w.wallhaven.cc/full/ab/wallhaven-abc123.jpg",
-                "thumbs": {
-                    "large": "https://th.wallhaven.cc/lg/ab/abc123.jpg",
-                    "original": "https://th.wallhaven.cc/orig/ab/abc123.jpg",
-                    "small": "https://th.wallhaven.cc/small/ab/abc123.jpg"
-                },
+                "thumbs": { "original": "https://th.wallhaven.cc/orig/ab/abc123.jpg" },
                 "tags": [
-                    {"id": 1, "name": "landscape", "alias": "", "category_id": 1, "category": "General", "purity": "sfw", "created_at": "2024-01-01"},
-                    {"id": 2, "name": "nature", "alias": "", "category_id": 1, "category": "General", "purity": "sfw", "created_at": "2024-01-01"}
+                    {"id": 1, "name": "landscape"},
+                    {"id": 2, "name": "nature"}
                 ]
             }
         ],
-        "meta": {
-            "current_page": 1,
-            "last_page": 1,
-            "per_page": 24,
-            "total": 1
-        }
+        "meta": { "current_page": 1, "last_page": 1, "per_page": 24, "total": 1 }
     }"##;
 
-    #[test]
-    fn test_parse_wallhaven_response() {
-        let resp: WallhavenResponse = serde_json::from_str(MOCK_RESPONSE).unwrap();
-        assert_eq!(resp.data.len(), 1);
-        let w = &resp.data[0];
-        assert_eq!(w.id, "abc123");
-        assert_eq!(w.dimension_x, 3840);
-        assert_eq!(w.dimension_y, 2160);
-        assert_eq!(w.tags.len(), 2);
-        assert_eq!(w.tags[0].name, "landscape");
+    fn source(http: Arc<StubFetch>) -> RestSource<WallhavenResponse, WallhavenDetailResponse> {
+        let desc = Descriptor {
+            source_type: "wallhaven",
+            display_name: "Wallhaven",
+            base: API_BASE,
+            auth: Auth::QueryParam {
+                key: "apikey",
+                value: Some("KEY".into()),
+            },
+            search_path: "/search",
+            detail_path: "/w",
+            query_key: "q",
+            per_page_param: None,
+            per_page_cap: 24,
+            block: 1,
+            extra_query: vec![("categories", "100".into()), ("purity", "100".into())],
+            server_aspect_param: Some("ratios"),
+        };
+        RestSource::new(desc, http)
     }
 
-    #[test]
-    fn test_wallhaven_to_preview() {
-        let resp: WallhavenResponse = serde_json::from_str(MOCK_RESPONSE).unwrap();
-        let previews: Vec<WallpaperPreview> = resp
-            .data
-            .into_iter()
-            .map(|w| WallpaperPreview {
-                source_type: SourceType::new("wallhaven"),
-                source_id: w.id.clone(),
-                source_url: w.url,
-                thumbnail_url: w.thumbs.original,
-                full_url: w.path,
-                width: w.dimension_x,
-                height: w.dimension_y,
-                tags: w.tags.into_iter().map(|t| t.name).collect(),
-            })
-            .collect();
+    #[tokio::test]
+    async fn maps_response_to_preview_with_tags() {
+        let http = Arc::new(StubFetch::ok(MOCK_RESPONSE));
+        let previews = source(http)
+            .search("x", 1, 24, AspectRatioFilter::All)
+            .await
+            .unwrap();
 
         assert_eq!(previews.len(), 1);
         assert_eq!(previews[0].source_id, "abc123");
         assert_eq!(previews[0].width, 3840);
         assert_eq!(previews[0].tags, vec!["landscape", "nature"]);
+    }
+
+    #[tokio::test]
+    async fn search_sends_q_apikey_categories_and_ratio() {
+        let http = Arc::new(StubFetch::ok(MOCK_RESPONSE));
+        source(http.clone())
+            .search("trees", 1, 24, AspectRatioFilter::Ratio16x9)
+            .await
+            .unwrap();
+
+        let call = http.last_call();
+        assert_eq!(call.query_value("q"), Some("trees"));
+        assert_eq!(call.query_value("apikey"), Some("KEY"));
+        assert_eq!(call.query_value("categories"), Some("100"));
+        assert_eq!(call.query_value("ratios"), Some("16x9"));
+        assert_eq!(call.query_value("per_page"), None); // not sent for wallhaven
+    }
+
+    #[test]
+    fn parses_id_from_both_url_forms() {
+        assert_eq!(
+            WallhavenDetailResponse::parse_id("https://wallhaven.cc/w/abc123"),
+            Some("abc123".into())
+        );
+        assert_eq!(
+            WallhavenDetailResponse::parse_id("https://whvn.cc/xyz789/"),
+            Some("xyz789".into())
+        );
+        assert_eq!(
+            WallhavenDetailResponse::parse_id("https://example.com/p/1"),
+            None
+        );
     }
 }


### PR DESCRIPTION
## Summary

Deepen the three REST API sources (wallhaven/unsplash/pexels) behind one shared engine instead of three near-identical clients. Each source dropped ~150 lines; the HTTP/pagination/download/filter/error logic now lives in one tested place.

## What changed

- **New crate `muralis-source-common`** — `RestSource<S, D>` is the single `WallpaperSource` for paged JSON REST APIs. It owns auth injection, request building, pagination, **page-filling** (block-mapped + client aspect filter + per-page cap), JSON parsing, and structured error context. Transport is the bytes-level `HttpFetch` seam (`ReqwestFetch` in prod, `StubFetch` in tests).
- **Sources reduced to data** — each crate is now response structs + `SearchResponse`/`DetailResponse` impls + a `Descriptor` (auth strategy, endpoints, per-page cap, block size, id parser).
- **Structured errors** — `MuralisError::Source { source_type, op, kind }` replaces the context-free `Source(String)`; HTTP/decode failures now carry source + operation + query.
- **Uniform aspect contract** — filtering moved out of the CLI into each source (feed honors it too). Fixes a latent bug where `has_more` was computed off post-filtered counts and broke under aspect filtering.
- Docs: `CONTEXT.md` added (RestSource, HttpFetch, Page-filling, Block); `CLAUDE.md` → 8 crates; `WallpaperSource::search` rustdoc states the best-effort page-filling contract.

## Design notes

Page-filling is stateless: logical page N maps to a fixed block of B upstream pages (`(N-1)*B+1 ..= N*B`), best-effort within the block — a page may return fewer than `per_page` even when more exist upstream. B=1 for wallhaven (server-side filter), B=3 for the client-filtered sources. Full rationale in `CONTEXT.md`.

## Testing

- 68 tests pass (`cargo test --workspace`); clippy + fmt clean
- 12 engine tests in `muralis-source-common` cover auth placement, block math, page-filling + cap, server-aspect skip, error context, resolve_url, download — all against the `StubFetch` fake (no network)
- Verified live against all three real APIs (16:9 and 21:9 searches): correct results, `has_more` now meaningful, page-filling fills to `per_page` or exhausts the block
- Launched the Qt GUI against the new build — searches/favorites route through the new engine correctly

## Follow-up (deferred)

Feed's `search` still does network I/O directly (not behind `HttpFetch`), so its aspect-filter isn't unit-tested. Porting feed to `HttpFetch` is a natural next deepening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)