### PR TITLE
feat: new sources (Pixabay, Booru multi-host) + content-safety ceiling

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -18,11 +18,40 @@ _Avoid_: ApiClient, RestClient, HttpSource
 The crate holding **RestSource**, **HttpFetch**, **Source Descriptor**, and the `SearchResponse`/`DetailResponse` traits. Depends on `muralis-core`; the wallhaven/unsplash/pexels crates depend on it.
 
 **Source Descriptor**:
-The per-source data a **RestSource** is built from: auth strategy, search/detail endpoint paths, upstream page cap, URL→id parser, block size B, and the response→**Preview** mapping.
+The per-source data a **RestSource** is built from: auth strategy, search/detail endpoint paths, page-param name + index base, upstream page cap, URL→id parser, block size B, and the response→**Preview** mapping.
 _Avoid_: config (that is the user's TOML), spec
+
+**Auth** (strategy):
+How a **RestSource** injects credentials. Variants: `QueryParam` (one key, wallhaven `apikey`), `Header` (unsplash/pexels), `QueryParams` (multiple query credentials together — Gelbooru's `api_key`+`user_id`, now mandatory since 2025), `None`. Secrets live here, never in `extra_query`.
 
 **Feed Source**:
 The non-REST **Source** backed by RSS/Atom; not a **RestSource** (no paged JSON API, fetches image dimensions itself).
+
+**Booru Source**:
+A **RestSource** for the danbooru-family imageboards (Danbooru, Moebooru = yande.re/Konachan, Gelbooru, e621…). One crate (`muralis-source-booru`), many hosts: configured as multiple instances (like **Feed Source**), each instance naming a host plus a **Flavor**. Tag-based search; dimensions present in the JSON. The NSFW/anime track. Aspect filtering is client-side **Page-filling** over a **Block** (no server aspect param) — boorus express aspect inside the `tags` string and cap unauthenticated searches at 2 tags, so the tag budget is spent on `rating:` + the user query, not aspect.
+_Avoid_: anime source, imageboard plugin (reserve "plugin" for the crate)
+
+**Flavor**:
+The API dialect of a **Booru Source** instance (`danbooru`, `moebooru`, `gelbooru`, …) — selects one **Source Descriptor** (endpoint path, page-param + index base, JSON envelope, detail-request shape). Multiple hosts share one Flavor (yande.re and Konachan are both `moebooru`). Distinct from **source_type**: Flavor is the dialect, source_type is the per-host identity.
+
+**source_type (booru)**:
+A **Booru Source** instance's stable per-host identity (e.g. `yandere`, `konachan`, `danbooru`, `gelbooru`), set from its config `name`. It is the dedup key alongside `source_id` — unlike the **Feed Source** (all feeds share `source_type="feed"` because feed `source_id`s are globally-unique URLs). Booru `source_id`s are bare host-local post numbers, so each host needs its own source_type or post `123` from two hosts would collide on `(source_id, source)`. `display_name` is cosmetic; `source_type` is identity.
+
+### Pixabay
+
+**Pixabay Source**:
+A one-host **RestSource** (own crate, like wallhaven). Minimal config: `enabled` + `api_key`. `orientation=horizontal` is a constant `extra_query` (landscape server-side, like pexels/unsplash), with **Page-filling** for exact ultrawide. Uniquely, it pushes the global `[filter] min_width/min_height` into its server-side `min_width`/`min_height` params (no other source can). Safe content only ever reaches "moderate" — Pixabay hosts no explicit tier — so the global ceiling maps to `safesearch` true/false.
+
+### Content safety
+
+**Content Safety policy**:
+A single global setting governing how much explicit content any **Source** may surface — not booru-specific. Cross-cutting: every Source that *can* return adult content maps the global policy onto its own native control (wallhaven → `purity`, **Booru Source** → `rating:` tag, pixabay → `safesearch`). Sources with no adult content (the SFW photo APIs, most feeds) ignore it. Reaching all plugins requires widening the `create_sources` plugin contract to receive global context, not just the `[sources]` table.
+
+**SourceContext**:
+The global cross-cutting context passed to every plugin's `create_sources` (`muralis-core`). Holds the **Content Safety policy** ceiling and global `min_width`/`min_height`. Designed to absorb future global knobs without re-churning the plugin contract. Plugins see this + their `[sources]` table, never the whole `Config`.
+_Avoid_: nsfw flag (it is a graded policy, not a boolean), rating (reserve for the booru tag)
+
+The policy is an **ordered level** — `safe` < `moderate` < `nsfw` — acting as a **ceiling**, not an override. Effective safety per source = the stricter of (global policy, source's native control). Global `safe` (the default) forces every source to its safest setting regardless of native config; global `nsfw` lets each source's native control (wallhaven `purity`, booru `rating`) decide up to that cap. A native knob can only tighten below the ceiling, never loosen past it — so a stale `purity="111"` cannot leak NSFW under a `safe` global.
 
 ### Search & paging
 
@@ -48,7 +77,9 @@ _Avoid_: HttpClient, Transport, Fetcher
 - A **RestSource** is built from exactly one **Source Descriptor** and one **HttpFetch** adapter.
 - A **RestSource** produces zero or more **Previews** per logical page via **Page-filling** over a **Block** of upstream pages.
 - The **Feed Source** is a **Source** but never a **RestSource**.
-- The `SourceRegistry` holds **Sources** (any mix of **RestSource** and **Feed Source**).
+- The `SourceRegistry` holds **Sources** (any mix of **RestSource**, **Booru Source**, **Pixabay Source**, **Feed Source**).
+- `create_sources` takes a **SourceContext** (global cross-cutting knobs: **Content Safety policy**, `min_width`/`min_height`) in addition to the `[sources]` table + client. The contract is the same for every plugin.
+- A gelbooru **Flavor** instance points at any gelbooru-clone host by `base` (gelbooru, rule34, safebooru, realbooru) — multi-host for free.
 
 ## Example dialogue
 
@@ -59,3 +90,4 @@ _Avoid_: HttpClient, Transport, Fetcher
 
 - "filter" was used for both the user's aspect choice and the act of discarding non-matching **Previews** — resolved: the choice is `AspectRatioFilter`; the act is part of **Page-filling**.
 - aspect filtering previously lived in the CLI caller (`main.rs:230`); it now lives in each **Source**: **RestSource** filters via **Page-filling**, and the **Feed Source** filters after resolving dimensions. The CLI no longer post-filters at all — every **Source** honors the aspect contract itself.
+- URL ownership for `favorites add` (`resolve_url`): the CLI tries every **Source** and takes the first that returns `Some`. With multiple **Booru Source** instances this is ambiguous (two moebooru hosts, same `/post/show/N` shape). Resolved: the engine's `resolve_url` host-matches the URL against the instance's `base` *before* delegating id extraction to the flavor — fixing a latent "first source that parses wins" ambiguity that predates booru. `parse_id` now extracts the id from the path only; the host check lives in the engine.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1616,6 +1616,7 @@ dependencies = [
  "muralis-core",
  "muralis-source-feed",
  "muralis-source-pexels",
+ "muralis-source-pixabay",
  "muralis-source-unsplash",
  "muralis-source-wallhaven",
  "reqwest",
@@ -1698,6 +1699,19 @@ dependencies = [
 
 [[package]]
 name = "muralis-source-pexels"
+version = "0.2.4"
+dependencies = [
+ "muralis-core",
+ "muralis-source-common",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "toml",
+]
+
+[[package]]
+name = "muralis-source-pixabay"
 version = "0.2.4"
 dependencies = [
  "muralis-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1614,6 +1614,7 @@ dependencies = [
  "anyhow",
  "clap",
  "muralis-core",
+ "muralis-source-booru",
  "muralis-source-feed",
  "muralis-source-pexels",
  "muralis-source-pixabay",
@@ -1665,6 +1666,20 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "muralis-source-booru"
+version = "0.2.4"
+dependencies = [
+ "muralis-core",
+ "muralis-source-common",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "toml",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "muralis-source-wallhaven",
     "muralis-source-unsplash",
     "muralis-source-pexels",
+    "muralis-source-pixabay",
     "muralis-source-feed",
 ]
 resolver = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "muralis-source-unsplash",
     "muralis-source-pexels",
     "muralis-source-pixabay",
+    "muralis-source-booru",
     "muralis-source-feed",
 ]
 resolver = "2"

--- a/README.md
+++ b/README.md
@@ -17,13 +17,14 @@
 
 ## Features
 
-- **Multi-Source Search**: Wallhaven, Unsplash, Pexels, and RSS/Atom feeds
+- **Multi-Source Search**: Wallhaven, Unsplash, Pexels, Pixabay, imageboards (danbooru/moebooru/gelbooru), and RSS/Atom feeds
 - **Plugin Architecture**: Add new sources by implementing a single trait
 - **Display Modes**: Static, Random, Sequential, Workspace-aware, Scheduled
 - **Favorites System**: SHA-256 deduplication, SQLite metadata, persistent library
 - **GUI**: Qt6/QML browser with source chips, feed dropdown, thumbnail grid, preview drawer
 - **Daemon**: Background service with IPC and workspace listener
 - **CLI**: Full daemon control via Unix socket
+- **Content-Safety Ceiling**: One global knob gates every source; nothing NSFW surfaces by default
 - **Wayland-Native**: hyprpaper and swww backends with transitions
 
 ## Installation
@@ -112,6 +113,7 @@ User config: `~/.config/muralis/config.toml`
 [general]
 backend = "swww"          # "swww" or "hyprpaper"
 cache_max_mb = 500        # Max cache size in MB
+content_safety = "safe"   # Global ceiling: "safe" < "moderate" < "nsfw"
 ```
 
 ### Display
@@ -149,29 +151,132 @@ min_height = 1440
 exclude_tags = ["anime", "cartoon"]
 ```
 
-### Sources
+`min_width`/`min_height` are pushed to sources that support a server-side
+dimension filter and applied as a client-side backstop everywhere else.
 
-Sources are plugin-based. Each source has its own config section:
+## Sources
+
+### Content-Safety Ceiling
+
+A single global ceiling gates **every** source. Set it in `[general]`:
+
+```toml
+[general]
+content_safety = "safe"   # "safe" < "moderate" < "nsfw"  (default: "safe")
+```
+
+It is a hard cap, not a per-source toggle:
+
+- **`safe`** (default) — every source is forced to its safest setting. Wallhaven
+  purity is clamped to SFW, Pixabay safesearch is on, and each booru is pinned to
+  its safest rating tag. Nothing sketchy or NSFW can surface.
+- **`moderate`** — allows sketchy/sensitive content; explicit/NSFW stays excluded.
+- **`nsfw`** — lifts the cap; sources may return explicit content.
+
+A source's own config can only *tighten* within the ceiling, never loosen past it.
+**Nothing NSFW-capable surfaces until you both enable a source _and_ raise the
+ceiling above `safe`.** Feeds are the exception — they are user-curated URLs that
+cannot be rated, so the ceiling cannot classify their images; point feeds only at
+URLs whose content you trust (e.g. choose SFW subreddits to stay SFW).
+
+### Configuring Sources
+
+Sources are plugin-based. Each has its own `[sources.*]` config section.
+
+#### Wallhaven
 
 ```toml
 [sources.wallhaven]
 enabled = true
-api_key = "optional"        # Required for NSFW/sketchy
-categories = "111"          # General/Anime/People
-purity = "100"              # SFW/Sketchy/NSFW
+api_key = "optional"    # Required for NSFW/sketchy purity
+categories = "111"      # General/Anime/People bitmask
+purity = "100"          # SFW/Sketchy/NSFW bitmask (clamped to the ceiling)
+```
 
+#### Unsplash
+
+```toml
 [sources.unsplash]
 enabled = true
-access_key = "your_key"
+access_key = "your_key"     # Create an app at https://unsplash.com/developers
+```
 
+#### Pexels
+
+```toml
 [sources.pexels]
 enabled = true
-
-[[sources.feeds]]
-name = "Bing Daily"
-url = "https://example.com/feed.rss"
-enabled = true
+api_key = "your_key"        # Generate at https://www.pexels.com/api/
 ```
+
+#### Pixabay
+
+```toml
+[sources.pixabay]
+enabled = true
+api_key = "your_key"        # Free key at https://pixabay.com/api/docs/
+```
+
+`safesearch` is driven by the ceiling: on at `safe`, off otherwise.
+
+#### Booru (imageboards)
+
+One `muralis-source-booru` crate serves many imageboard hosts. Add one
+`[[sources.booru]]` block per host (like feeds):
+
+- **`name`** — per-host identity, also the dedup key. Must be a known host (table below).
+- **`flavor`** — the API dialect (response shape + endpoints).
+
+| `flavor`   | Hosts (`name`)                                | Notes |
+|------------|-----------------------------------------------|-------|
+| `danbooru` | `danbooru`                                     | `/posts.json` flat array |
+| `moebooru` | `yandere` (yande.re), `konachan`               | `/post.json`; resolve-by-id via `tags=id:N` |
+| `gelbooru` | `gelbooru`, `rule34`, `safebooru`, `realbooru` | `dapi` JSON; `gelbooru` needs `api_key` + `user_id` |
+
+```toml
+[[sources.booru]]
+enabled = true
+name = "danbooru"
+flavor = "danbooru"
+
+[[sources.booru]]              # NSFW track — needs ceiling above "safe"
+enabled = true
+name = "gelbooru"
+flavor = "gelbooru"
+api_key = "YOUR_GELBOORU_API_KEY"
+user_id = "YOUR_GELBOORU_USER_ID"
+```
+
+Gelbooru credentials are **mandatory** on gelbooru.com since 2025 (anonymous
+search returns `401`). Generate them at **gelbooru.com → Account → Options →
+API Access Credentials**. The clones (`rule34`/`safebooru`/`realbooru`) are
+`flavor = "gelbooru"` on a different host and allow anonymous access.
+
+> **Single-tag queries work best.** Boorus cap anonymous searches at 2 tags, and
+> muralis spends one slot on the content-safety rating tag — so a one-word query
+> (e.g. `landscape`) leaves room for the rating, while multi-word queries may be
+> rejected.
+
+#### Feeds (RSS/Atom)
+
+Any RSS/Atom feed with image enclosures works — no API key. This is also how you
+pull subreddits: append `.rss` to any subreddit URL.
+
+```toml
+[[sources.feeds]]
+enabled = true
+name = "Imaginary Landscapes"
+url = "https://www.reddit.com/r/ImaginaryLandscapes/.rss"
+
+# Ultrawide / widescreen wallpaper subreddits:
+# [[sources.feeds]]
+# enabled = false
+# name = "Ultrawide Master Race"
+# url = "https://www.reddit.com/r/ultrawidemasterrace/.rss"
+```
+
+See [`assets/demo-config.toml`](assets/demo-config.toml) for a fully annotated
+example covering every source plus the Reddit-as-feed recipes (ultrawide + NSFW).
 
 ### Workspace Mode
 
@@ -202,22 +307,29 @@ tags = ["dark", "night"]
 ```
 muralis/
 ├── muralis-core/              # Shared library (traits, models, config, DB, IPC)
+├── muralis-source-common/     # Shared RestSource engine + HttpFetch transport seam
 ├── muralis-cli/               # CLI binary (clap)
 ├── muralis-daemon/            # Background service (IPC, display engine)
 ├── muralis-gui/               # Qt6/QML GUI (C++ + QML, calls CLI via QProcess)
 ├── muralis-source-wallhaven/  # Wallhaven API plugin
 ├── muralis-source-unsplash/   # Unsplash API plugin
 ├── muralis-source-pexels/     # Pexels API plugin
+├── muralis-source-pixabay/    # Pixabay API plugin
+├── muralis-source-booru/      # Multi-host imageboard plugin (danbooru/moebooru/gelbooru)
 └── muralis-source-feed/       # RSS/Atom feed plugin
 ```
 
 ### Adding a New Source
 
 1. Create `muralis-source-foo/` implementing `WallpaperSource` trait
-2. Export `pub fn create_sources(table: &toml::Table, client: reqwest::Client) -> Vec<Box<dyn WallpaperSource>>`
+2. Export `pub fn create_sources(table: &toml::Table, client: reqwest::Client, ctx: &SourceContext) -> Vec<Box<dyn WallpaperSource>>`
 3. Add to workspace `Cargo.toml`
 4. Add one line in `build_registry()` in `muralis-cli/src/main.rs`
 5. Add `[sources.foo]` to config
+
+`ctx: &SourceContext` (from `muralis-core::sources`) carries the global
+`content_safety` ceiling and `min_width`/`min_height`. Honor it: clamp any
+NSFW-capable output to the ceiling and apply the minimum dimensions.
 
 ### Data Paths
 

--- a/assets/demo-config.toml
+++ b/assets/demo-config.toml
@@ -32,6 +32,29 @@ enabled = false
 [sources.pexels]
 enabled = false
 
+# Booru sources (anime/NSFW track) — one [[sources.booru]] per host.
+#   name   = per-host identity (also the dedup key). Known hosts only for now:
+#            danbooru, yandere, konachan.
+#   flavor = API dialect: "danbooru" or "moebooru" (yande.re + Konachan).
+# All disabled by example. Nothing NSFW can surface until you BOTH enable a
+# source AND raise [general] content_safety above "safe" (see issue #7 docs):
+# at the default "safe" ceiling every booru is forced to its safest rating.
+#
+# [[sources.booru]]
+# enabled = false
+# name = "danbooru"
+# flavor = "danbooru"
+#
+# [[sources.booru]]
+# enabled = false
+# name = "yandere"
+# flavor = "moebooru"
+#
+# [[sources.booru]]
+# enabled = false
+# name = "konachan"
+# flavor = "moebooru"
+
 [filter]
 min_width = 1920
 min_height = 1080

--- a/assets/demo-config.toml
+++ b/assets/demo-config.toml
@@ -4,6 +4,11 @@ schedules = []
 [general]
 backend = "swww"
 cache_max_mb = 500
+# Global content-safety ceiling gating EVERY source: "safe" < "moderate"
+# < "nsfw". At the default "safe" every source is forced to its safest
+# setting and nothing NSFW can surface. Raise it AND enable an NSFW-capable
+# source to opt in. (Feeds are user-curated URLs and cannot be rated.)
+content_safety = "safe"
 
 [display]
 mode = "random_startup"
@@ -21,6 +26,34 @@ enabled = true
 name = "Landscapes"
 url = "https://www.reddit.com/r/ImaginaryLandscapes/.rss"
 
+# Reddit-as-feed: append `.rss` to any subreddit URL. No API key needed; the
+# Feed source ingests the RSS image enclosures like any other feed.
+#
+# Ultrawide / widescreen wallpaper subreddits:
+# [[sources.feeds]]
+# enabled = false
+# name = "Ultrawide Master Race"
+# url = "https://www.reddit.com/r/ultrawidemasterrace/.rss"
+#
+# [[sources.feeds]]
+# enabled = false
+# name = "Widescreen Wallpaper"
+# url = "https://www.reddit.com/r/WidescreenWallpaper/.rss"
+#
+# [[sources.feeds]]
+# enabled = false
+# name = "Multiwall"
+# url = "https://www.reddit.com/r/multiwall/.rss"
+#
+# NSFW subreddit feeds (NSFW — adult content). Feeds are user-curated and
+# cannot be rated, so the content_safety ceiling does NOT filter them; enable
+# only if you want unfiltered adult content. Replace <nsfw_subreddit> with any
+# adult subreddit name:
+# [[sources.feeds]]
+# enabled = false
+# name = "NSFW Wallpapers"
+# url = "https://www.reddit.com/r/<nsfw_subreddit>/.rss"
+
 [sources.wallhaven]
 enabled = true
 categories = "100"
@@ -31,6 +64,12 @@ enabled = false
 
 [sources.pexels]
 enabled = false
+
+# Pixabay — free API key at https://pixabay.com/api/docs/ . safesearch follows
+# the content_safety ceiling (on at "safe").
+[sources.pixabay]
+enabled = false
+# api_key = "YOUR_PIXABAY_API_KEY"
 
 # Booru sources (anime/NSFW track) — one [[sources.booru]] per host.
 #   name   = per-host identity (also the dedup key). Known hosts only for now:

--- a/assets/demo-config.toml
+++ b/assets/demo-config.toml
@@ -34,8 +34,12 @@ enabled = false
 
 # Booru sources (anime/NSFW track) — one [[sources.booru]] per host.
 #   name   = per-host identity (also the dedup key). Known hosts only for now:
-#            danbooru, yandere, konachan.
-#   flavor = API dialect: "danbooru" or "moebooru" (yande.re + Konachan).
+#            danbooru, yandere, konachan, gelbooru, rule34, safebooru, realbooru.
+#   flavor = API dialect: "danbooru", "moebooru" (yande.re + Konachan), or
+#            "gelbooru" (gelbooru.com + clones rule34/safebooru/realbooru).
+#   Gelbooru-flavor hosts need api_key + user_id (mandatory on gelbooru.com
+#   since 2025; anonymous = 401). Generate them at gelbooru.com → Account →
+#   Options → API Access Credentials.
 # All disabled by example. Nothing NSFW can surface until you BOTH enable a
 # source AND raise [general] content_safety above "safe" (see issue #7 docs):
 # at the default "safe" ceiling every booru is forced to its safest rating.
@@ -54,6 +58,20 @@ enabled = false
 # enabled = false
 # name = "konachan"
 # flavor = "moebooru"
+#
+# [[sources.booru]]  # NSFW — gelbooru needs api_key + user_id
+# enabled = false
+# name = "gelbooru"
+# flavor = "gelbooru"
+# api_key = "YOUR_GELBOORU_API_KEY"
+# user_id = "YOUR_GELBOORU_USER_ID"
+#
+# [[sources.booru]]  # NSFW — rule34 is flavor=gelbooru on a different host
+# enabled = false
+# name = "rule34"
+# flavor = "gelbooru"
+# api_key = "YOUR_RULE34_API_KEY"
+# user_id = "YOUR_RULE34_USER_ID"
 
 [filter]
 min_width = 1920

--- a/muralis-cli/Cargo.toml
+++ b/muralis-cli/Cargo.toml
@@ -14,6 +14,7 @@ muralis-source-wallhaven = { path = "../muralis-source-wallhaven" }
 muralis-source-unsplash = { path = "../muralis-source-unsplash" }
 muralis-source-pexels = { path = "../muralis-source-pexels" }
 muralis-source-pixabay = { path = "../muralis-source-pixabay" }
+muralis-source-booru = { path = "../muralis-source-booru" }
 muralis-source-feed = { path = "../muralis-source-feed" }
 tokio = { workspace = true }
 anyhow = { workspace = true }

--- a/muralis-cli/Cargo.toml
+++ b/muralis-cli/Cargo.toml
@@ -13,6 +13,7 @@ muralis-core = { path = "../muralis-core" }
 muralis-source-wallhaven = { path = "../muralis-source-wallhaven" }
 muralis-source-unsplash = { path = "../muralis-source-unsplash" }
 muralis-source-pexels = { path = "../muralis-source-pexels" }
+muralis-source-pixabay = { path = "../muralis-source-pixabay" }
 muralis-source-feed = { path = "../muralis-source-feed" }
 tokio = { workspace = true }
 anyhow = { workspace = true }

--- a/muralis-cli/src/main.rs
+++ b/muralis-cli/src/main.rs
@@ -161,6 +161,9 @@ fn build_registry(config: &Config) -> Result<(SourceRegistry, reqwest::Client)> 
     for s in muralis_source_pixabay::create_sources(sources, client.clone(), &ctx) {
         registry.register(s);
     }
+    for s in muralis_source_booru::create_sources(sources, client.clone(), &ctx) {
+        registry.register(s);
+    }
     for s in muralis_source_feed::create_sources(sources, client.clone(), &ctx) {
         registry.register(s);
     }

--- a/muralis-cli/src/main.rs
+++ b/muralis-cli/src/main.rs
@@ -7,7 +7,7 @@ use muralis_core::db::Database;
 use muralis_core::ipc::{self, IpcRequest, IpcResponse};
 use muralis_core::models::DisplayMode;
 use muralis_core::paths::MuralisPaths;
-use muralis_core::sources::{AspectRatioFilter, SourceRegistry, WallpaperSource};
+use muralis_core::sources::{AspectRatioFilter, SourceContext, SourceRegistry, WallpaperSource};
 use muralis_core::wallpapers::WallpaperManager;
 
 #[derive(Parser)]
@@ -140,18 +140,28 @@ fn build_registry(config: &Config) -> Result<(SourceRegistry, reqwest::Client)> 
         ))
         .build()?;
     let sources = &config.sources;
+    // Build the global cross-cutting context once (ADR 0003): content-safety
+    // ceiling from [general], min dimensions from [filter].
+    let ctx = SourceContext {
+        content_safety: config.general.content_safety,
+        min_width: config.filter.min_width,
+        min_height: config.filter.min_height,
+    };
     let mut registry = SourceRegistry::new();
 
-    for s in muralis_source_wallhaven::create_sources(sources, client.clone()) {
+    for s in muralis_source_wallhaven::create_sources(sources, client.clone(), &ctx) {
         registry.register(s);
     }
-    for s in muralis_source_unsplash::create_sources(sources, client.clone()) {
+    for s in muralis_source_unsplash::create_sources(sources, client.clone(), &ctx) {
         registry.register(s);
     }
-    for s in muralis_source_pexels::create_sources(sources, client.clone()) {
+    for s in muralis_source_pexels::create_sources(sources, client.clone(), &ctx) {
         registry.register(s);
     }
-    for s in muralis_source_feed::create_sources(sources, client.clone()) {
+    for s in muralis_source_pixabay::create_sources(sources, client.clone(), &ctx) {
+        registry.register(s);
+    }
+    for s in muralis_source_feed::create_sources(sources, client.clone(), &ctx) {
         registry.register(s);
     }
 

--- a/muralis-core/src/config.rs
+++ b/muralis-core/src/config.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::error::{MuralisError, Result};
 use crate::models::{BackendType, DisplayMode};
 use crate::paths::MuralisPaths;
+use crate::sources::ContentSafety;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -69,6 +70,10 @@ pub struct GeneralConfig {
     pub backend: BackendType,
     pub cache_max_mb: u64,
     pub thumbnail_zoom: f32,
+    /// Global content-safety ceiling (ADR 0002). Default `safe` — the panic
+    /// switch that forces every source to its safest native setting.
+    #[serde(default)]
+    pub content_safety: ContentSafety,
 }
 
 impl Default for GeneralConfig {
@@ -77,6 +82,7 @@ impl Default for GeneralConfig {
             backend: BackendType::Hyprpaper,
             cache_max_mb: 500,
             thumbnail_zoom: 1.0,
+            content_safety: ContentSafety::default(),
         }
     }
 }

--- a/muralis-core/src/sources/context.rs
+++ b/muralis-core/src/sources/context.rs
@@ -1,0 +1,58 @@
+//! Global cross-cutting context handed to every source plugin's
+//! `create_sources`. See ADR 0002 (content-safety ceiling) and ADR 0003
+//! (SourceContext plugin contract).
+
+use serde::{Deserialize, Serialize};
+
+/// Global content-safety ceiling — an ordered level acting as a cap, not an
+/// override (ADR 0002). Effective safety per source is the *stricter* of this
+/// global ceiling and the source's native control, so a source's native knob
+/// (wallhaven `purity`, booru `rating:`) can only tighten below the ceiling,
+/// never loosen past it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum ContentSafety {
+    /// SFW only — the default and the panic switch.
+    #[default]
+    Safe,
+    /// Suggestive/sensitive content allowed, no explicit.
+    Moderate,
+    /// Explicit content allowed, up to each source's native cap.
+    Nsfw,
+}
+
+/// Global cross-cutting knobs passed to every plugin's `create_sources`
+/// (ADR 0003). Designed to absorb future global settings without re-churning
+/// the plugin contract. Plugins see this plus their own `[sources]` table,
+/// never the whole `Config`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SourceContext {
+    pub content_safety: ContentSafety,
+    pub min_width: u32,
+    pub min_height: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn content_safety_is_ordered_safe_lt_moderate_lt_nsfw() {
+        assert!(ContentSafety::Safe < ContentSafety::Moderate);
+        assert!(ContentSafety::Moderate < ContentSafety::Nsfw);
+        assert!(ContentSafety::Safe < ContentSafety::Nsfw);
+    }
+
+    #[test]
+    fn content_safety_default_is_safe() {
+        assert_eq!(ContentSafety::default(), ContentSafety::Safe);
+    }
+
+    #[test]
+    fn content_safety_deserializes_lowercase() {
+        let v: ContentSafety = toml::from_str("v = \"moderate\"")
+            .map(|t: toml::Table| t["v"].clone().try_into().unwrap())
+            .unwrap();
+        assert_eq!(v, ContentSafety::Moderate);
+    }
+}

--- a/muralis-core/src/sources/mod.rs
+++ b/muralis-core/src/sources/mod.rs
@@ -5,6 +5,9 @@ use async_trait::async_trait;
 use crate::error::Result;
 use crate::models::WallpaperPreview;
 
+pub mod context;
+pub use context::{ContentSafety, SourceContext};
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AspectRatioFilter {
     All,

--- a/muralis-source-booru/Cargo.toml
+++ b/muralis-source-booru/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "muralis-source-booru"
+edition.workspace = true
+version.workspace = true
+license.workspace = true
+
+[dependencies]
+muralis-core = { path = "../muralis-core" }
+muralis-source-common = { path = "../muralis-source-common" }
+reqwest = { workspace = true }
+serde = { workspace = true }
+toml = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }
+serde_json = { workspace = true }

--- a/muralis-source-booru/src/lib.rs
+++ b/muralis-source-booru/src/lib.rs
@@ -39,6 +39,12 @@ pub struct BooruConfig {
     /// only, never past the ceiling) is a follow-up.
     #[serde(default)]
     pub rating: Option<String>,
+    /// Gelbooru-flavor credentials. Both are mandatory on gelbooru.com since
+    /// 2025 (anonymous search returns 401); clones (rule34 etc.) ignore them.
+    #[serde(default)]
+    pub api_key: Option<String>,
+    #[serde(default)]
+    pub user_id: Option<String>,
 }
 
 pub fn create_sources(
@@ -86,6 +92,16 @@ pub fn create_sources(
                     RestSource::<MoebooruResponse, MoebooruResponse>::new(desc, http.clone()),
                 ));
             }
+            "gelbooru" => {
+                let mut desc = descriptor(&cfg.name, base, "/index.php", "/index.php", tag_prefix);
+                desc.auth = gelbooru_auth(&cfg);
+                desc.extra_query = gelbooru_query_params();
+                desc.page_param = "pid"; // gelbooru paginates with 0-indexed pid
+                desc.page_base = 0;
+                out.push(Box::new(
+                    RestSource::<GelbooruResponse, GelbooruResponse>::new(desc, http.clone()),
+                ));
+            }
             other => tracing::warn!("booru: unknown flavor {other:?} for {:?}", cfg.name),
         }
     }
@@ -115,6 +131,8 @@ fn descriptor(
         block: BLOCK,
         extra_query: Vec::new(),
         server_aspect_param: None,
+        page_param: "page",
+        page_base: 1,
     }
 }
 
@@ -126,6 +144,11 @@ fn default_base(name: &str) -> Option<&'static str> {
         "danbooru" => "https://danbooru.donmai.us",
         "yandere" | "yande.re" => "https://yande.re",
         "konachan" => "https://konachan.com",
+        // gelbooru flavor: gelbooru.com plus its clones, which share the API.
+        "gelbooru" => "https://gelbooru.com",
+        "rule34" => "https://rule34.xxx",
+        "safebooru" => "https://safebooru.org",
+        "realbooru" => "https://realbooru.com",
         _ => return None,
     })
 }
@@ -143,6 +166,12 @@ fn rating_prefix(flavor: &str, ceiling: ContentSafety) -> Option<String> {
         },
         "moebooru" => match ceiling {
             ContentSafety::Safe => "rating:safe",
+            ContentSafety::Moderate => "-rating:explicit",
+            ContentSafety::Nsfw => "",
+        },
+        // Modern gelbooru uses general/sensitive/questionable/explicit.
+        "gelbooru" => match ceiling {
+            ContentSafety::Safe => "rating:general",
             ContentSafety::Moderate => "-rating:explicit",
             ContentSafety::Nsfw => "",
         },
@@ -315,6 +344,126 @@ impl DetailResponse for MoebooruResponse {
     }
 }
 
+// -- gelbooru flavor (gelbooru.com + clones rule34/safebooru/realbooru):
+//    `/index.php?page=dapi&s=post&q=index&json=1` → `{"post":[…]}`; `pid`
+//    0-indexed pagination; detail by `&id=N` query (no path-based id) --
+
+#[derive(Debug, Deserialize)]
+pub struct GelbooruResponse {
+    // Absent (not `[]`) when there are no results, so default to empty.
+    #[serde(default)]
+    post: Vec<GelbooruPost>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GelbooruPost {
+    id: u64,
+    #[serde(default)]
+    width: u32,
+    #[serde(default)]
+    height: u32,
+    #[serde(default)]
+    file_url: String,
+    #[serde(default)]
+    sample_url: String,
+    #[serde(default)]
+    preview_url: String,
+    #[serde(default)]
+    tags: String,
+}
+
+impl GelbooruPost {
+    fn into_preview(self, source_type: &str) -> WallpaperPreview {
+        let full = first_nonempty([self.file_url, self.sample_url, self.preview_url]);
+        WallpaperPreview {
+            source_type: SourceType::new(source_type),
+            source_id: self.id.to_string(),
+            source_url: full.full.clone(),
+            thumbnail_url: full.thumb,
+            full_url: full.full,
+            width: self.width,
+            height: self.height,
+            tags: split_tags(&self.tags),
+        }
+    }
+}
+
+impl SearchResponse for GelbooruResponse {
+    fn into_previews(self, source_type: &str) -> Vec<WallpaperPreview> {
+        self.post
+            .into_iter()
+            .map(|p| p.into_preview(source_type))
+            .collect()
+    }
+}
+
+impl DetailResponse for GelbooruResponse {
+    fn into_preview(self, source_type: &str) -> WallpaperPreview {
+        self.post
+            .into_iter()
+            .next()
+            .map(|p| p.into_preview(source_type))
+            .unwrap_or_else(|| WallpaperPreview {
+                source_type: SourceType::new(source_type),
+                source_id: String::new(),
+                source_url: String::new(),
+                thumbnail_url: String::new(),
+                full_url: String::new(),
+                width: 0,
+                height: 0,
+                tags: Vec::new(),
+            })
+    }
+    fn parse_id(url: &str) -> Option<String> {
+        // gelbooru post pages are `index.php?page=post&s=view&id=N`.
+        id_from_query(url, "id")
+    }
+    const HOST_SCOPED: bool = true;
+    fn detail_request(
+        base: &str,
+        _detail_path: &str,
+        search_path: &str,
+        id: &str,
+    ) -> (String, Vec<(&'static str, String)>) {
+        let mut q = gelbooru_query_params();
+        q.push(("id", id.to_string()));
+        (format!("{base}{search_path}"), q)
+    }
+}
+
+/// `Auth` for a gelbooru instance: both `api_key` and `user_id` together when
+/// configured (mandatory on gelbooru.com), else `None` (clones allow anonymous).
+fn gelbooru_auth(cfg: &BooruConfig) -> Auth {
+    match (&cfg.api_key, &cfg.user_id) {
+        (Some(k), Some(u)) => {
+            Auth::QueryParams(vec![("api_key", k.clone()), ("user_id", u.clone())])
+        }
+        _ => Auth::None,
+    }
+}
+
+/// The constant params that select gelbooru's `dapi` JSON post-index endpoint.
+fn gelbooru_query_params() -> Vec<(&'static str, String)> {
+    vec![
+        ("page", "dapi".to_string()),
+        ("s", "post".to_string()),
+        ("q", "index".to_string()),
+        ("json", "1".to_string()),
+    ]
+}
+
+/// Value of query parameter `key` in a URL (`…?s=view&id=42#x` with key `id` →
+/// `42`), or `None` if the key is absent or empty.
+fn id_from_query(url: &str, key: &str) -> Option<String> {
+    let query = url.split_once('?')?.1;
+    query
+        .split('&')
+        .filter_map(|kv| kv.split_once('='))
+        .find(|(k, _)| *k == key)
+        .map(|(_, v)| v.split('#').next().unwrap_or(v).to_string())
+        .filter(|v| !v.is_empty())
+}
+
 // -- shared mapping helpers --
 
 struct Urls {
@@ -383,6 +532,29 @@ mod tests {
             "/post",
             rating_prefix("moebooru", ctx.content_safety),
         );
+        RestSource::new(desc, http)
+    }
+
+    fn gelbooru(
+        name: &str,
+        base: &'static str,
+        http: Arc<StubFetch>,
+        ctx: &SourceContext,
+    ) -> RestSource<GelbooruResponse, GelbooruResponse> {
+        let mut desc = descriptor(
+            name,
+            base,
+            "/index.php",
+            "/index.php",
+            rating_prefix("gelbooru", ctx.content_safety),
+        );
+        desc.auth = Auth::QueryParams(vec![
+            ("api_key", "KEY".to_string()),
+            ("user_id", "42".to_string()),
+        ]);
+        desc.extra_query = gelbooru_query_params();
+        desc.page_param = "pid";
+        desc.page_base = 0;
         RestSource::new(desc, http)
     }
 
@@ -511,6 +683,102 @@ mod tests {
         assert!(http.calls().is_empty(), "must not hit the network");
     }
 
+    const GELBOORU_BODY: &str = r#"{"post":[
+        {"id":99,"width":3840,"height":1600,
+         "file_url":"https://img3.gelbooru.com/images/99.jpg",
+         "sample_url":"https://img3.gelbooru.com/samples/99.jpg",
+         "preview_url":"https://img3.gelbooru.com/thumbnails/99.jpg",
+         "tags":"scenery wide"}
+    ]}"#;
+
+    #[tokio::test]
+    async fn gelbooru_parses_post_envelope_folds_rating_and_pages_zero_indexed() {
+        let http = Arc::new(StubFetch::ok_pages(&[
+            GELBOORU_BODY,
+            r#"{"post":[]}"#,
+            r#"{"post":[]}"#,
+        ]));
+        let previews = gelbooru(
+            "gelbooru",
+            "https://gelbooru.com",
+            http.clone(),
+            &safe_ctx(),
+        )
+        .search("scenery", 1, 24, AspectRatioFilter::All)
+        .await
+        .unwrap();
+
+        assert_eq!(previews.len(), 1);
+        assert_eq!(previews[0].source_id, "99");
+        assert_eq!(previews[0].width, 3840);
+        assert_eq!(
+            previews[0].full_url,
+            "https://img3.gelbooru.com/images/99.jpg"
+        );
+
+        let calls = http.calls();
+        // both credentials injected into the query (dual-credential auth)
+        assert_eq!(calls[0].query_value("api_key"), Some("KEY"));
+        assert_eq!(calls[0].query_value("user_id"), Some("42"));
+        assert_eq!(calls[0].query_value("json"), Some("1"));
+        // safe ceiling → rating:general folded ahead of the user query
+        assert_eq!(calls[0].query_value("tags"), Some("rating:general scenery"));
+        // 0-indexed pid: logical page 1, block 3 → pid 0,1,2
+        let pids: Vec<_> = calls
+            .iter()
+            .map(|c| c.query_value("pid").unwrap().to_string())
+            .collect();
+        assert_eq!(pids, vec!["0", "1", "2"]);
+    }
+
+    #[tokio::test]
+    async fn gelbooru_resolves_via_id_query() {
+        let http = Arc::new(StubFetch::ok(GELBOORU_BODY));
+        let preview = gelbooru(
+            "gelbooru",
+            "https://gelbooru.com",
+            http.clone(),
+            &safe_ctx(),
+        )
+        .resolve_url("https://gelbooru.com/index.php?page=post&s=view&id=99")
+        .await
+        .unwrap()
+        .expect("gelbooru resolves its own host");
+
+        assert_eq!(preview.source_id, "99");
+        let call = http.last_call();
+        assert_eq!(call.url, "https://gelbooru.com/index.php");
+        assert_eq!(call.query_value("id"), Some("99"));
+        assert_eq!(call.query_value("api_key"), Some("KEY"));
+    }
+
+    #[test]
+    fn create_sources_builds_gelbooru_and_rule34_multi_host() {
+        let toml_str = r#"
+            [[booru]]
+            name = "gelbooru"
+            flavor = "gelbooru"
+            enabled = true
+            api_key = "abc"
+            user_id = "7"
+
+            [[booru]]
+            name = "rule34"
+            flavor = "gelbooru"
+            enabled = true
+            api_key = "def"
+            user_id = "9"
+        "#;
+        let table: toml::Table = toml_str.parse().unwrap();
+        let sources = create_sources(&table, reqwest::Client::new(), &safe_ctx());
+        // both gelbooru-flavor hosts build on different bases (multi-host)
+        let names: Vec<_> = sources
+            .iter()
+            .map(|s| s.source_type().to_string())
+            .collect();
+        assert_eq!(names, vec!["gelbooru", "rule34"]);
+    }
+
     #[test]
     fn rating_prefix_tracks_the_ceiling() {
         assert_eq!(
@@ -527,6 +795,15 @@ mod tests {
             Some("rating:safe")
         );
         assert_eq!(rating_prefix("moebooru", ContentSafety::Nsfw), None);
+        assert_eq!(
+            rating_prefix("gelbooru", ContentSafety::Safe).as_deref(),
+            Some("rating:general")
+        );
+        assert_eq!(
+            rating_prefix("gelbooru", ContentSafety::Moderate).as_deref(),
+            Some("-rating:explicit")
+        );
+        assert_eq!(rating_prefix("gelbooru", ContentSafety::Nsfw), None);
     }
 
     #[test]

--- a/muralis-source-booru/src/lib.rs
+++ b/muralis-source-booru/src/lib.rs
@@ -1,0 +1,564 @@
+//! Multi-host booru source: one crate, many imageboard hosts, configured as
+//! multiple `[[sources.booru]]` instances (like the feed source). Each instance
+//! names a host (`name` → per-host `source_type`/dedup identity) plus a `flavor`
+//! (the API dialect → which response shape + endpoints). See `CONTEXT.md`
+//! ("Booru Source", "Flavor", "source_type (booru)").
+//!
+//! Boorus are tag-based with no usable server aspect param, so aspect filtering
+//! is client-side page-filling over a block (`BLOCK`). The 2-tag cap on
+//! unauthenticated search means the tag budget goes to `rating:` + the user
+//! query — the `rating:` tag is derived from the global content-safety ceiling
+//! and folded ahead of the query by the shared engine (`Descriptor.tag_prefix`).
+
+use std::sync::Arc;
+
+use serde::Deserialize;
+
+use muralis_core::models::{SourceType, WallpaperPreview};
+use muralis_core::sources::{ContentSafety, SourceContext, WallpaperSource};
+use muralis_source_common::{
+    Auth, Descriptor, DetailResponse, HttpFetch, ReqwestFetch, RestSource, SearchResponse,
+};
+
+/// Upstream pages consumed per logical page. Boorus filter aspect client-side,
+/// so over-fetch a block to fill an ultrawide page (Block B > 1).
+const BLOCK: u32 = 3;
+/// Per-upstream-page size. Kept modest: a block already fetches `BLOCK ×` this.
+const PER_PAGE_CAP: u32 = 40;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct BooruConfig {
+    /// Per-host identity → `source_type` (dedup key) and display name.
+    pub name: String,
+    /// API dialect → which flavor descriptor (`danbooru`, `moebooru`).
+    pub flavor: String,
+    #[serde(default)]
+    pub enabled: bool,
+    /// Optional per-instance rating override. Reserved: the rating tag is
+    /// derived from the global ceiling for now; honoring an override (tighten
+    /// only, never past the ceiling) is a follow-up.
+    #[serde(default)]
+    pub rating: Option<String>,
+}
+
+pub fn create_sources(
+    table: &toml::Table,
+    client: reqwest::Client,
+    ctx: &SourceContext,
+) -> Vec<Box<dyn WallpaperSource>> {
+    let Some(arr) = table.get("booru").and_then(|v| v.as_array()) else {
+        return Vec::new();
+    };
+    let http: Arc<dyn HttpFetch> = Arc::new(ReqwestFetch(client));
+    let mut out: Vec<Box<dyn WallpaperSource>> = Vec::new();
+
+    for item in arr {
+        let cfg: BooruConfig = match item.clone().try_into() {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!("booru: skipping malformed instance: {e}");
+                continue;
+            }
+        };
+        if !cfg.enabled {
+            continue;
+        }
+        let Some(base) = default_base(&cfg.name) else {
+            tracing::warn!(
+                "booru: unknown host name {:?}; no known base, skipping",
+                cfg.name
+            );
+            continue;
+        };
+        let tag_prefix = rating_prefix(&cfg.flavor, ctx.content_safety);
+
+        match cfg.flavor.as_str() {
+            "danbooru" => {
+                let desc = descriptor(&cfg.name, base, "/posts.json", "/posts", tag_prefix);
+                out.push(Box::new(RestSource::<DanbooruSearch, DanbooruPost>::new(
+                    desc,
+                    http.clone(),
+                )));
+            }
+            "moebooru" => {
+                let desc = descriptor(&cfg.name, base, "/post.json", "/post", tag_prefix);
+                out.push(Box::new(
+                    RestSource::<MoebooruResponse, MoebooruResponse>::new(desc, http.clone()),
+                ));
+            }
+            other => tracing::warn!("booru: unknown flavor {other:?} for {:?}", cfg.name),
+        }
+    }
+    out
+}
+
+/// Shared descriptor shape for every booru flavor: tag search, no server
+/// aspect param (client-side block filtering), 1-indexed `page`.
+fn descriptor(
+    name: &str,
+    base: &'static str,
+    search_path: &'static str,
+    detail_path: &'static str,
+    tag_prefix: Option<String>,
+) -> Descriptor {
+    Descriptor {
+        source_type: name.to_string(),
+        display_name: name.to_string(),
+        base,
+        auth: Auth::None,
+        search_path,
+        detail_path,
+        query_key: "tags",
+        tag_prefix,
+        per_page_param: Some("limit"),
+        per_page_cap: PER_PAGE_CAP,
+        block: BLOCK,
+        extra_query: Vec::new(),
+        server_aspect_param: None,
+    }
+}
+
+/// Known host bases keyed by config `name`. Arbitrary hosts (gelbooru clones
+/// like rule34) join this table per flavor; `base` stays `&'static` so the
+/// shared `Descriptor` is unchanged.
+fn default_base(name: &str) -> Option<&'static str> {
+    Some(match name {
+        "danbooru" => "https://danbooru.donmai.us",
+        "yandere" | "yande.re" => "https://yande.re",
+        "konachan" => "https://konachan.com",
+        _ => return None,
+    })
+}
+
+/// The `rating:` tag for a flavor under the global ceiling. The ceiling is a
+/// cap: `Safe` forces the single safest rating (never leaks); `Moderate`
+/// excludes only explicit; `Nsfw` adds no rating tag (full range up to the
+/// host's own cap).
+fn rating_prefix(flavor: &str, ceiling: ContentSafety) -> Option<String> {
+    let tag = match flavor {
+        "danbooru" => match ceiling {
+            ContentSafety::Safe => "rating:g",
+            ContentSafety::Moderate => "-rating:e",
+            ContentSafety::Nsfw => "",
+        },
+        "moebooru" => match ceiling {
+            ContentSafety::Safe => "rating:safe",
+            ContentSafety::Moderate => "-rating:explicit",
+            ContentSafety::Nsfw => "",
+        },
+        _ => "",
+    };
+    (!tag.is_empty()).then(|| tag.to_string())
+}
+
+/// Path portion of a URL (`scheme://host/PATH`), or `None` if there is none.
+fn path_of(url: &str) -> Option<&str> {
+    url.split_once("://")?.1.split_once('/').map(|(_, p)| p)
+}
+
+/// First path segment after `prefix`, e.g. `posts/123?foo` minus `posts/` → `123`.
+fn id_after(path: &str, prefix: &str) -> Option<String> {
+    let rest = path.strip_prefix(prefix)?;
+    let seg = rest.split(['/', '?', '#']).next()?;
+    (!seg.is_empty()).then(|| seg.to_string())
+}
+
+// -- danbooru flavor: `/posts.json` flat array, detail `/posts/{id}.json` --
+
+#[derive(Debug, Deserialize)]
+#[serde(transparent)]
+pub struct DanbooruSearch(Vec<DanbooruPost>);
+
+#[derive(Debug, Deserialize)]
+pub struct DanbooruPost {
+    id: u64,
+    #[serde(default)]
+    image_width: u32,
+    #[serde(default)]
+    image_height: u32,
+    #[serde(default)]
+    file_url: String,
+    #[serde(default)]
+    large_file_url: String,
+    #[serde(default)]
+    preview_file_url: String,
+    #[serde(default)]
+    tag_string: String,
+}
+
+impl SearchResponse for DanbooruSearch {
+    fn into_previews(self, source_type: &str) -> Vec<WallpaperPreview> {
+        self.0
+            .into_iter()
+            .map(|p| p.into_preview(source_type))
+            .collect()
+    }
+}
+
+impl DetailResponse for DanbooruPost {
+    fn into_preview(self, source_type: &str) -> WallpaperPreview {
+        let full = first_nonempty([self.file_url, self.large_file_url, self.preview_file_url]);
+        WallpaperPreview {
+            source_type: SourceType::new(source_type),
+            source_id: self.id.to_string(),
+            // No post-page URL in the JSON and the mapper lacks `base`; use the
+            // image URL (cosmetic — dedup keys on (source_id, source_type)).
+            source_url: full.full.clone(),
+            thumbnail_url: full.thumb,
+            full_url: full.full,
+            width: self.image_width,
+            height: self.image_height,
+            tags: split_tags(&self.tag_string),
+        }
+    }
+    fn parse_id(url: &str) -> Option<String> {
+        id_after(path_of(url)?, "posts/")
+    }
+    const HOST_SCOPED: bool = true;
+    fn detail_request(
+        base: &str,
+        detail_path: &str,
+        _search_path: &str,
+        id: &str,
+    ) -> (String, Vec<(&'static str, String)>) {
+        (format!("{base}{detail_path}/{id}.json"), Vec::new())
+    }
+}
+
+// -- moebooru flavor (yande.re, Konachan): `/post.json` flat array; no
+//    GET-by-id, so resolve via `/post.json?tags=id:{id}` --
+
+#[derive(Debug, Deserialize)]
+#[serde(transparent)]
+pub struct MoebooruResponse(Vec<MoebooruPost>);
+
+#[derive(Debug, Deserialize)]
+pub struct MoebooruPost {
+    id: u64,
+    #[serde(default)]
+    width: u32,
+    #[serde(default)]
+    height: u32,
+    #[serde(default)]
+    file_url: String,
+    #[serde(default)]
+    jpeg_url: String,
+    #[serde(default)]
+    sample_url: String,
+    #[serde(default)]
+    preview_url: String,
+    #[serde(default)]
+    tags: String,
+}
+
+impl MoebooruPost {
+    fn into_preview(self, source_type: &str) -> WallpaperPreview {
+        let full = first_nonempty([self.file_url, self.jpeg_url, self.sample_url]);
+        let thumb = if self.preview_url.is_empty() {
+            full.thumb
+        } else {
+            self.preview_url
+        };
+        WallpaperPreview {
+            source_type: SourceType::new(source_type),
+            source_id: self.id.to_string(),
+            source_url: full.full.clone(),
+            thumbnail_url: thumb,
+            full_url: full.full,
+            width: self.width,
+            height: self.height,
+            tags: split_tags(&self.tags),
+        }
+    }
+}
+
+impl SearchResponse for MoebooruResponse {
+    fn into_previews(self, source_type: &str) -> Vec<WallpaperPreview> {
+        self.0
+            .into_iter()
+            .map(|p| p.into_preview(source_type))
+            .collect()
+    }
+}
+
+impl DetailResponse for MoebooruResponse {
+    fn into_preview(self, source_type: &str) -> WallpaperPreview {
+        self.0
+            .into_iter()
+            .next()
+            .map(|p| p.into_preview(source_type))
+            .unwrap_or_else(|| WallpaperPreview {
+                source_type: SourceType::new(source_type),
+                source_id: String::new(),
+                source_url: String::new(),
+                thumbnail_url: String::new(),
+                full_url: String::new(),
+                width: 0,
+                height: 0,
+                tags: Vec::new(),
+            })
+    }
+    fn parse_id(url: &str) -> Option<String> {
+        id_after(path_of(url)?, "post/show/")
+    }
+    const HOST_SCOPED: bool = true;
+    fn detail_request(
+        base: &str,
+        _detail_path: &str,
+        search_path: &str,
+        id: &str,
+    ) -> (String, Vec<(&'static str, String)>) {
+        (
+            format!("{base}{search_path}"),
+            vec![("tags", format!("id:{id}"))],
+        )
+    }
+}
+
+// -- shared mapping helpers --
+
+struct Urls {
+    full: String,
+    thumb: String,
+}
+
+/// Pick the first non-empty URL as the full image; the last as a thumb fallback.
+fn first_nonempty<const N: usize>(candidates: [String; N]) -> Urls {
+    let full = candidates
+        .iter()
+        .find(|c| !c.is_empty())
+        .cloned()
+        .unwrap_or_default();
+    let thumb = candidates
+        .iter()
+        .rev()
+        .find(|c| !c.is_empty())
+        .cloned()
+        .unwrap_or_else(|| full.clone());
+    Urls { full, thumb }
+}
+
+fn split_tags(s: &str) -> Vec<String> {
+    s.split_whitespace().map(|t| t.to_string()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use muralis_core::sources::AspectRatioFilter;
+    use muralis_source_common::testing::StubFetch;
+
+    fn safe_ctx() -> SourceContext {
+        SourceContext {
+            content_safety: ContentSafety::Safe,
+            min_width: 1920,
+            min_height: 1080,
+        }
+    }
+
+    fn danbooru(
+        http: Arc<StubFetch>,
+        ctx: &SourceContext,
+    ) -> RestSource<DanbooruSearch, DanbooruPost> {
+        let desc = descriptor(
+            "danbooru",
+            "https://danbooru.donmai.us",
+            "/posts.json",
+            "/posts",
+            rating_prefix("danbooru", ctx.content_safety),
+        );
+        RestSource::new(desc, http)
+    }
+
+    fn moebooru(
+        name: &str,
+        base: &'static str,
+        http: Arc<StubFetch>,
+        ctx: &SourceContext,
+    ) -> RestSource<MoebooruResponse, MoebooruResponse> {
+        let desc = descriptor(
+            name,
+            base,
+            "/post.json",
+            "/post",
+            rating_prefix("moebooru", ctx.content_safety),
+        );
+        RestSource::new(desc, http)
+    }
+
+    const DANBOORU_BODY: &str = r#"[
+        {"id":1,"image_width":3440,"image_height":1440,
+         "file_url":"https://cdn.donmai.us/orig/1.jpg",
+         "large_file_url":"https://cdn.donmai.us/sample/1.jpg",
+         "preview_file_url":"https://cdn.donmai.us/preview/1.jpg",
+         "tag_string":"landscape scenery"}
+    ]"#;
+
+    #[tokio::test]
+    async fn danbooru_parses_array_and_maps_preview() {
+        let http = Arc::new(StubFetch::ok_pages(&[DANBOORU_BODY, "[]", "[]"]));
+        let previews = danbooru(http, &safe_ctx())
+            .search("landscape", 1, 24, AspectRatioFilter::All)
+            .await
+            .unwrap();
+
+        assert_eq!(previews.len(), 1);
+        assert_eq!(previews[0].source_id, "1");
+        assert_eq!(previews[0].width, 3440);
+        assert_eq!(previews[0].full_url, "https://cdn.donmai.us/orig/1.jpg");
+        assert_eq!(
+            previews[0].thumbnail_url,
+            "https://cdn.donmai.us/preview/1.jpg"
+        );
+        assert_eq!(previews[0].tags, vec!["landscape", "scenery"]);
+    }
+
+    #[tokio::test]
+    async fn danbooru_folds_rating_tag_and_pages_one_indexed() {
+        let http = Arc::new(StubFetch::ok_pages(&["[]", "[]", "[]"]));
+        danbooru(http.clone(), &safe_ctx())
+            .search("forest", 2, 24, AspectRatioFilter::All)
+            .await
+            .unwrap();
+
+        let calls = http.calls();
+        // safe ceiling → rating:g folded ahead of the query in the `tags` param
+        assert_eq!(calls[0].query_value("tags"), Some("rating:g forest"));
+        assert_eq!(calls[0].url, "https://danbooru.donmai.us/posts.json");
+        assert_eq!(calls[0].query_value("limit"), Some("40"));
+        // logical page 2, block 3 → upstream pages 4,5,6 (1-indexed)
+        let pages: Vec<_> = calls
+            .iter()
+            .map(|c| c.query_value("page").unwrap().to_string())
+            .collect();
+        assert_eq!(pages, vec!["4", "5", "6"]);
+    }
+
+    #[tokio::test]
+    async fn danbooru_resolves_post_url_via_json_detail() {
+        let body = r#"{"id":7,"image_width":1920,"image_height":1080,
+            "file_url":"https://cdn.donmai.us/orig/7.jpg","tag_string":"sky"}"#;
+        let http = Arc::new(StubFetch::ok(body));
+        let preview = danbooru(http.clone(), &safe_ctx())
+            .resolve_url("https://danbooru.donmai.us/posts/7")
+            .await
+            .unwrap()
+            .expect("danbooru resolves its own host");
+
+        assert_eq!(preview.source_id, "7");
+        assert_eq!(
+            http.last_call().url,
+            "https://danbooru.donmai.us/posts/7.json"
+        );
+    }
+
+    const MOEBOORU_BODY: &str = r#"[
+        {"id":42,"width":2560,"height":1080,
+         "file_url":"https://files.yande.re/image/42.jpg",
+         "sample_url":"https://files.yande.re/sample/42.jpg",
+         "preview_url":"https://files.yande.re/preview/42.jpg",
+         "tags":"original long_hair"}
+    ]"#;
+
+    #[tokio::test]
+    async fn moebooru_parses_array_and_folds_rating() {
+        let http = Arc::new(StubFetch::ok_pages(&[MOEBOORU_BODY, "[]", "[]"]));
+        let previews = moebooru("yandere", "https://yande.re", http.clone(), &safe_ctx())
+            .search("original", 1, 24, AspectRatioFilter::All)
+            .await
+            .unwrap();
+
+        assert_eq!(previews.len(), 1);
+        assert_eq!(previews[0].source_id, "42");
+        assert_eq!(previews[0].full_url, "https://files.yande.re/image/42.jpg");
+        assert_eq!(
+            http.calls()[0].query_value("tags"),
+            Some("rating:safe original")
+        );
+    }
+
+    #[tokio::test]
+    async fn moebooru_resolves_via_search_by_id() {
+        let http = Arc::new(StubFetch::ok(MOEBOORU_BODY));
+        let preview = moebooru("yandere", "https://yande.re", http.clone(), &safe_ctx())
+            .resolve_url("https://yande.re/post/show/42")
+            .await
+            .unwrap()
+            .expect("matching host resolves");
+
+        assert_eq!(preview.source_id, "42");
+        let call = http.last_call();
+        assert_eq!(call.url, "https://yande.re/post.json");
+        assert_eq!(call.query_value("tags"), Some("id:42"));
+    }
+
+    #[tokio::test]
+    async fn two_moebooru_hosts_do_not_collide_on_resolution() {
+        // a konachan instance must reject a yande.re URL (same path shape) in
+        // the engine, before any network call — host_scoped guards it.
+        let http = Arc::new(StubFetch::ok(MOEBOORU_BODY));
+        let resolved = moebooru(
+            "konachan",
+            "https://konachan.com",
+            http.clone(),
+            &safe_ctx(),
+        )
+        .resolve_url("https://yande.re/post/show/42")
+        .await
+        .unwrap();
+
+        assert!(resolved.is_none());
+        assert!(http.calls().is_empty(), "must not hit the network");
+    }
+
+    #[test]
+    fn rating_prefix_tracks_the_ceiling() {
+        assert_eq!(
+            rating_prefix("danbooru", ContentSafety::Safe).as_deref(),
+            Some("rating:g")
+        );
+        assert_eq!(
+            rating_prefix("danbooru", ContentSafety::Moderate).as_deref(),
+            Some("-rating:e")
+        );
+        assert_eq!(rating_prefix("danbooru", ContentSafety::Nsfw), None);
+        assert_eq!(
+            rating_prefix("moebooru", ContentSafety::Safe).as_deref(),
+            Some("rating:safe")
+        );
+        assert_eq!(rating_prefix("moebooru", ContentSafety::Nsfw), None);
+    }
+
+    #[test]
+    fn create_sources_builds_enabled_known_hosts_only() {
+        let toml_str = r#"
+            [[booru]]
+            name = "danbooru"
+            flavor = "danbooru"
+            enabled = true
+
+            [[booru]]
+            name = "yandere"
+            flavor = "moebooru"
+            enabled = true
+
+            [[booru]]
+            name = "konachan"
+            flavor = "moebooru"
+            enabled = false
+
+            [[booru]]
+            name = "unknownhost"
+            flavor = "danbooru"
+            enabled = true
+        "#;
+        let table: toml::Table = toml_str.parse().unwrap();
+        let sources = create_sources(&table, reqwest::Client::new(), &safe_ctx());
+        // danbooru + yandere enabled & known; konachan disabled; unknownhost skipped
+        let names: Vec<_> = sources
+            .iter()
+            .map(|s| s.source_type().to_string())
+            .collect();
+        assert_eq!(names, vec!["danbooru", "yandere"]);
+    }
+}

--- a/muralis-source-common/src/lib.rs
+++ b/muralis-source-common/src/lib.rs
@@ -61,6 +61,10 @@ pub enum Auth {
         key: &'static str,
         value: Option<String>,
     },
+    /// Multiple query credentials sent together — Gelbooru requires both
+    /// `api_key` and `user_id` (mandatory since 2025; anonymous = 401). Secrets
+    /// live here, never in `extra_query`.
+    QueryParams(Vec<(&'static str, String)>),
     /// Sent as a header, e.g. unsplash `Authorization: Client-ID …`.
     Header {
         name: &'static str,
@@ -98,6 +102,12 @@ pub struct Descriptor {
     /// When `Some(key)`, the server filters by aspect via this query param
     /// (wallhaven `ratios`); client-side filtering is then skipped.
     pub server_aspect_param: Option<&'static str>,
+    /// Query key for the page number. Almost always `"page"`; Gelbooru uses
+    /// `"pid"`.
+    pub page_param: &'static str,
+    /// First page index the API uses. `1` for most sources; Gelbooru's `pid` is
+    /// `0`-indexed.
+    pub page_base: u32,
 }
 
 /// A source's search-response envelope.
@@ -195,12 +205,18 @@ where
 
         let mut out: Vec<WallpaperPreview> = Vec::new();
         for upstream in first..=last {
-            let upstream_s = upstream.to_string();
+            // Map the internal 1-indexed upstream page onto the API's own page
+            // numbering: most APIs are 1-indexed (`page_base` 1); Gelbooru's
+            // `pid` is 0-indexed (`page_base` 0).
+            let page_num = upstream - 1 + self.desc.page_base;
+            let page_num_s = page_num.to_string();
             let cap_s = self.desc.per_page_cap.to_string();
             let q_value: &str = composed_query.as_deref().unwrap_or(query);
 
-            let mut query_params: Vec<(&str, &str)> =
-                vec![(self.desc.query_key, q_value), ("page", &upstream_s)];
+            let mut query_params: Vec<(&str, &str)> = vec![
+                (self.desc.query_key, q_value),
+                (self.desc.page_param, &page_num_s),
+            ];
             if let Some(pp) = self.desc.per_page_param {
                 query_params.push((pp, &cap_s));
             }
@@ -217,6 +233,11 @@ where
                     key,
                     value: Some(v),
                 } => query_params.push((key, v.as_str())),
+                Auth::QueryParams(pairs) => {
+                    for (k, v) in pairs {
+                        query_params.push((k, v.as_str()));
+                    }
+                }
                 Auth::Header { name, value } => headers.push((name, value.as_str())),
                 _ => {}
             }
@@ -274,6 +295,11 @@ where
                 key,
                 value: Some(v),
             } => query_params.push((key, v.as_str())),
+            Auth::QueryParams(pairs) => {
+                for (k, v) in pairs {
+                    query_params.push((k, v.as_str()));
+                }
+            }
             Auth::Header { name, value } => headers.push((name, value.as_str())),
             _ => {}
         }
@@ -393,6 +419,8 @@ mod tests {
             block: 1,
             extra_query: Vec::new(),
             server_aspect_param: None,
+            page_param: "page",
+            page_base: 1,
         }
     }
 
@@ -615,6 +643,50 @@ mod tests {
         src.search("", 1, 24, AspectRatioFilter::All).await.unwrap();
 
         assert_eq!(http.last_call().query_value("tags"), Some("rating:safe"));
+    }
+
+    #[tokio::test]
+    async fn auth_query_params_injects_all_pairs() {
+        let mut desc = descriptor();
+        desc.auth = Auth::QueryParams(vec![("api_key", "abc".into()), ("user_id", "7".into())]);
+        let http = Arc::new(StubFetch::ok(r#"{"items":[]}"#));
+        let src: RestSource<FixSearch, FixItem> = RestSource::new(desc, http.clone());
+
+        src.search("x", 1, 24, AspectRatioFilter::All)
+            .await
+            .unwrap();
+
+        let call = http.last_call();
+        assert_eq!(call.query_value("api_key"), Some("abc"));
+        assert_eq!(call.query_value("user_id"), Some("7"));
+    }
+
+    #[tokio::test]
+    async fn page_param_and_base_map_zero_indexed_pages() {
+        let mut desc = descriptor();
+        desc.page_param = "pid";
+        desc.page_base = 0;
+        desc.block = 3;
+        let http = Arc::new(StubFetch::ok_pages(&[
+            r#"{"items":[]}"#,
+            r#"{"items":[]}"#,
+            r#"{"items":[]}"#,
+        ]));
+        let src: RestSource<FixSearch, FixItem> = RestSource::new(desc, http.clone());
+
+        // logical page 1, block 3, 0-indexed → pid 0,1,2 under the "pid" key
+        src.search("x", 1, 100, AspectRatioFilter::All)
+            .await
+            .unwrap();
+
+        let pids: Vec<_> = http
+            .calls()
+            .iter()
+            .map(|c| c.query_value("pid").unwrap().to_string())
+            .collect();
+        assert_eq!(pids, vec!["0", "1", "2"]);
+        // the default "page" key is unused once page_param is overridden
+        assert_eq!(http.last_call().query_value("page"), None);
     }
 
     // -- host-scoped resolve fixture: parse_id is path-only, host check is the

--- a/muralis-source-common/src/lib.rs
+++ b/muralis-source-common/src/lib.rs
@@ -72,14 +72,20 @@ pub enum Auth {
 /// Per-source data a [`RestSource`] is built from. No behaviour beyond the
 /// mappers carried by the response traits.
 pub struct Descriptor {
-    pub source_type: &'static str,
-    pub display_name: &'static str,
+    /// Per-host identity + dedup key. `String` (not `&'static str`) because
+    /// multi-host sources (boorus) derive it from config `name` at runtime.
+    pub source_type: String,
+    pub display_name: String,
     pub base: &'static str,
     pub auth: Auth,
     pub search_path: &'static str,
     pub detail_path: &'static str,
     /// Query key for the search term: `"q"` (wallhaven) or `"query"`.
     pub query_key: &'static str,
+    /// Folded into the search-term value: the engine sends
+    /// `"{tag_prefix} {query}"` (trimmed) as `query_key`. Carries a booru's
+    /// `rating:` tag (+ any extra tags); `None` when the query stands alone.
+    pub tag_prefix: Option<String>,
     /// Query key for page size, or `None` when the API has no such param
     /// (wallhaven uses a fixed server page size).
     pub per_page_param: Option<&'static str>,
@@ -103,8 +109,30 @@ pub trait SearchResponse: DeserializeOwned + Send {
 pub trait DetailResponse: DeserializeOwned + Send {
     fn into_preview(self, source_type: &str) -> WallpaperPreview;
     /// Parse this source's wallpaper id out of a page URL, or `None` if the
-    /// URL doesn't belong to this source.
+    /// URL doesn't belong to this source. When [`Self::HOST_SCOPED`] is set the
+    /// engine has already host-matched, so the flavor may parse the path alone.
     fn parse_id(url: &str) -> Option<String>;
+
+    /// When `true`, `resolve_url` requires the URL's host to equal the
+    /// descriptor `base`'s host before calling [`Self::parse_id`]. Multi-host
+    /// boorus set this so two instances of one flavor (yande.re + Konachan,
+    /// both `/post/show/N`) don't fight over the same path shape. Single-host
+    /// sources whose API host differs from their page host leave it `false`.
+    const HOST_SCOPED: bool = false;
+
+    /// Build the `(url, extra_query)` for the detail fetch. Default is
+    /// path-based `{base}{detail_path}/{id}` with no extra query — the photo
+    /// APIs. Flavors override for a `.json` suffix (danbooru) or a search-by-id
+    /// query shape (moebooru has no GET-by-id: `tags=id:{id}`).
+    fn detail_request(
+        base: &str,
+        detail_path: &str,
+        search_path: &str,
+        id: &str,
+    ) -> (String, Vec<(&'static str, String)>) {
+        let _ = search_path;
+        (format!("{base}{detail_path}/{id}"), Vec::new())
+    }
 }
 
 /// The deep module: a full [`WallpaperSource`] for paged JSON REST APIs.
@@ -131,11 +159,11 @@ where
     D: DetailResponse + 'static,
 {
     fn name(&self) -> &str {
-        self.desc.display_name
+        &self.desc.display_name
     }
 
     fn source_type(&self) -> &str {
-        self.desc.source_type
+        &self.desc.source_type
     }
 
     async fn search(
@@ -157,13 +185,22 @@ where
             .zip(aspect.to_wallhaven_ratio());
         let client_filter = self.desc.server_aspect_param.is_none();
 
+        // Compose the search-term value once: a booru folds its `rating:` tag
+        // (+ extra tags) ahead of the user query into the single `tags` param.
+        let composed_query = self
+            .desc
+            .tag_prefix
+            .as_ref()
+            .map(|p| format!("{p} {query}").trim().to_string());
+
         let mut out: Vec<WallpaperPreview> = Vec::new();
         for upstream in first..=last {
             let upstream_s = upstream.to_string();
             let cap_s = self.desc.per_page_cap.to_string();
+            let q_value: &str = composed_query.as_deref().unwrap_or(query);
 
             let mut query_params: Vec<(&str, &str)> =
-                vec![(self.desc.query_key, query), ("page", &upstream_s)];
+                vec![(self.desc.query_key, q_value), ("page", &upstream_s)];
             if let Some(pp) = self.desc.per_page_param {
                 query_params.push((pp, &cap_s));
             }
@@ -200,7 +237,7 @@ where
                 )
             })?;
 
-            for preview in resp.into_previews(self.desc.source_type) {
+            for preview in resp.into_previews(&self.desc.source_type) {
                 if client_filter && !aspect.matches(preview.width, preview.height) {
                     continue;
                 }
@@ -214,10 +251,21 @@ where
     }
 
     async fn resolve_url(&self, url: &str) -> Result<Option<WallpaperPreview>> {
+        // Host-scoped sources (multi-host boorus) reject foreign hosts in the
+        // engine *before* delegating to the flavor's path-only `parse_id`, so
+        // two instances of one flavor don't fight over the same URL shape.
+        if D::HOST_SCOPED && !host_matches(url, self.desc.base) {
+            return Ok(None);
+        }
         let Some(id) = D::parse_id(url) else {
             return Ok(None);
         };
-        let endpoint = format!("{}{}/{}", self.desc.base, self.desc.detail_path, id);
+        let (endpoint, extra) = D::detail_request(
+            self.desc.base,
+            self.desc.detail_path,
+            self.desc.search_path,
+            &id,
+        );
 
         let mut headers: Vec<(&str, &str)> = Vec::new();
         let mut query_params: Vec<(&str, &str)> = Vec::new();
@@ -229,6 +277,9 @@ where
             Auth::Header { name, value } => headers.push((name, value.as_str())),
             _ => {}
         }
+        for (k, v) in &extra {
+            query_params.push((k, v.as_str()));
+        }
 
         let (status, bytes) = self.http.get(&endpoint, &headers, &query_params).await?;
         if !status.is_success() {
@@ -236,7 +287,7 @@ where
         }
         let resp: D = serde_json::from_slice(&bytes)
             .map_err(|e| self.err("resolve", &endpoint, format!("decode: {e}")))?;
-        Ok(Some(resp.into_preview(self.desc.source_type)))
+        Ok(Some(resp.into_preview(&self.desc.source_type)))
     }
 
     async fn download(&self, preview: &WallpaperPreview) -> Result<bytes::Bytes> {
@@ -251,10 +302,28 @@ where
 impl<S, D> RestSource<S, D> {
     fn err(&self, op: &str, detail: &str, kind: String) -> MuralisError {
         MuralisError::Source {
-            source_type: self.desc.source_type.to_string(),
+            source_type: self.desc.source_type.clone(),
             op: format!("{op} {detail}"),
             kind,
         }
+    }
+}
+
+/// Host portion of a URL/base (`scheme://HOST/...`), or `None` if absent.
+fn host_of(url: &str) -> Option<&str> {
+    let after_scheme = url.split_once("://").map(|(_, r)| r).unwrap_or(url);
+    let host = after_scheme
+        .split(['/', '?', '#'])
+        .next()
+        .unwrap_or(after_scheme);
+    (!host.is_empty()).then_some(host)
+}
+
+/// Whether `url`'s host equals `base`'s host (case-insensitive).
+fn host_matches(url: &str, base: &str) -> bool {
+    match (host_of(url), host_of(base)) {
+        (Some(a), Some(b)) => a.eq_ignore_ascii_case(b),
+        _ => false,
     }
 }
 
@@ -311,13 +380,14 @@ mod tests {
 
     fn descriptor() -> Descriptor {
         Descriptor {
-            source_type: "fix",
-            display_name: "Fixture",
+            source_type: "fix".into(),
+            display_name: "Fixture".into(),
             base: "https://api.fix.test",
             auth: Auth::None,
             search_path: "/search",
             detail_path: "/photo",
             query_key: "query",
+            tag_prefix: None,
             per_page_param: Some("per_page"),
             per_page_cap: 30,
             block: 1,
@@ -514,6 +584,103 @@ mod tests {
 
         assert_eq!(preview.source_id, "d9");
         assert_eq!(http.last_call().url, "https://api.fix.test/photo/d9");
+    }
+
+    #[tokio::test]
+    async fn tag_prefix_is_folded_ahead_of_the_query() {
+        let mut desc = descriptor();
+        desc.query_key = "tags";
+        desc.tag_prefix = Some("rating:safe".into());
+        let http = Arc::new(StubFetch::ok(r#"{"items":[]}"#));
+        let src: RestSource<FixSearch, FixItem> = RestSource::new(desc, http.clone());
+
+        src.search("landscape", 1, 24, AspectRatioFilter::All)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            http.last_call().query_value("tags"),
+            Some("rating:safe landscape")
+        );
+    }
+
+    #[tokio::test]
+    async fn tag_prefix_alone_when_query_empty() {
+        let mut desc = descriptor();
+        desc.query_key = "tags";
+        desc.tag_prefix = Some("rating:safe".into());
+        let http = Arc::new(StubFetch::ok(r#"{"items":[]}"#));
+        let src: RestSource<FixSearch, FixItem> = RestSource::new(desc, http.clone());
+
+        src.search("", 1, 24, AspectRatioFilter::All).await.unwrap();
+
+        assert_eq!(http.last_call().query_value("tags"), Some("rating:safe"));
+    }
+
+    // -- host-scoped resolve fixture: parse_id is path-only, host check is the
+    //    engine's job (HOST_SCOPED) --
+
+    #[derive(Deserialize)]
+    struct HostScopedItem {
+        id: String,
+        w: u32,
+        h: u32,
+    }
+
+    impl DetailResponse for HostScopedItem {
+        fn into_preview(self, source_type: &str) -> WallpaperPreview {
+            WallpaperPreview {
+                source_type: SourceType::new(source_type),
+                source_id: self.id,
+                source_url: String::new(),
+                thumbnail_url: String::new(),
+                full_url: String::new(),
+                width: self.w,
+                height: self.h,
+                tags: Vec::new(),
+            }
+        }
+        // path-only: "post/show/123" -> "123"
+        fn parse_id(url: &str) -> Option<String> {
+            let path = url.split_once("://")?.1.split_once('/')?.1;
+            let id = path.strip_prefix("post/show/")?;
+            let id = id.split(['/', '?', '#']).next()?;
+            (!id.is_empty()).then(|| id.to_string())
+        }
+        const HOST_SCOPED: bool = true;
+    }
+
+    #[tokio::test]
+    async fn host_scoped_rejects_foreign_host_without_fetching() {
+        let mut desc = descriptor();
+        desc.base = "https://yande.re";
+        let http = Arc::new(StubFetch::ok(r#"{"id":"123","w":1,"h":1}"#));
+        let src: RestSource<FixSearch, HostScopedItem> = RestSource::new(desc, http.clone());
+
+        // same path shape, different host -> rejected before any network call
+        let resolved = src
+            .resolve_url("https://konachan.com/post/show/123")
+            .await
+            .unwrap();
+
+        assert!(resolved.is_none());
+        assert!(http.calls().is_empty(), "must not hit the network");
+    }
+
+    #[tokio::test]
+    async fn host_scoped_resolves_matching_host() {
+        let mut desc = descriptor();
+        desc.base = "https://yande.re";
+        let http = Arc::new(StubFetch::ok(r#"{"id":"123","w":3440,"h":1440}"#));
+        let src: RestSource<FixSearch, HostScopedItem> = RestSource::new(desc, http.clone());
+
+        let preview = src
+            .resolve_url("https://yande.re/post/show/123")
+            .await
+            .unwrap()
+            .expect("matching host resolves");
+
+        assert_eq!(preview.source_id, "123");
     }
 
     #[tokio::test]

--- a/muralis-source-feed/src/lib.rs
+++ b/muralis-source-feed/src/lib.rs
@@ -9,7 +9,7 @@ use tokio::sync::Semaphore;
 
 use muralis_core::error::Result;
 use muralis_core::models::{SourceType, WallpaperPreview};
-use muralis_core::sources::{AspectRatioFilter, WallpaperSource};
+use muralis_core::sources::{AspectRatioFilter, SourceContext, WallpaperSource};
 
 static IMG_SEL: LazyLock<Selector> =
     LazyLock::new(|| Selector::parse("img[src]").expect("valid selector"));
@@ -31,6 +31,7 @@ pub struct FeedConfig {
 pub fn create_sources(
     table: &toml::Table,
     client: reqwest::Client,
+    _ctx: &SourceContext,
 ) -> Vec<Box<dyn WallpaperSource>> {
     let Some(val) = table.get("feeds") else {
         return Vec::new();
@@ -444,7 +445,7 @@ mod tests {
         "#;
         let table: toml::Table = toml_str.parse().unwrap();
         let client = reqwest::Client::new();
-        let sources = create_sources(&table, client);
+        let sources = create_sources(&table, client, &SourceContext::default());
         assert_eq!(sources.len(), 1);
         assert_eq!(sources[0].name(), "active");
     }

--- a/muralis-source-pexels/src/lib.rs
+++ b/muralis-source-pexels/src/lib.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use serde::Deserialize;
 
 use muralis_core::models::{SourceType, WallpaperPreview};
-use muralis_core::sources::WallpaperSource;
+use muralis_core::sources::{SourceContext, WallpaperSource};
 use muralis_source_common::{
     Auth, Descriptor, DetailResponse, ReqwestFetch, RestSource, SearchResponse,
 };
@@ -23,6 +23,7 @@ pub struct PexelsConfig {
 pub fn create_sources(
     table: &toml::Table,
     client: reqwest::Client,
+    _ctx: &SourceContext,
 ) -> Vec<Box<dyn WallpaperSource>> {
     let Some(val) = table.get("pexels") else {
         return Vec::new();

--- a/muralis-source-pexels/src/lib.rs
+++ b/muralis-source-pexels/src/lib.rs
@@ -37,8 +37,8 @@ pub fn create_sources(
     };
 
     let desc = Descriptor {
-        source_type: "pexels",
-        display_name: "Pexels",
+        source_type: "pexels".into(),
+        display_name: "Pexels".into(),
         base: API_BASE,
         auth: Auth::Header {
             name: "Authorization",
@@ -47,6 +47,7 @@ pub fn create_sources(
         search_path: "/search",
         detail_path: "/photos",
         query_key: "query",
+        tag_prefix: None,
         per_page_param: Some("per_page"),
         per_page_cap: 80,
         block: BLOCK,
@@ -143,8 +144,8 @@ mod tests {
 
     fn source(http: Arc<StubFetch>) -> RestSource<PexelsSearchResponse, PexelsPhoto> {
         let desc = Descriptor {
-            source_type: "pexels",
-            display_name: "Pexels",
+            source_type: "pexels".into(),
+            display_name: "Pexels".into(),
             base: API_BASE,
             auth: Auth::Header {
                 name: "Authorization",
@@ -153,6 +154,7 @@ mod tests {
             search_path: "/search",
             detail_path: "/photos",
             query_key: "query",
+            tag_prefix: None,
             per_page_param: Some("per_page"),
             per_page_cap: 80,
             block: BLOCK,

--- a/muralis-source-pexels/src/lib.rs
+++ b/muralis-source-pexels/src/lib.rs
@@ -53,6 +53,8 @@ pub fn create_sources(
         block: BLOCK,
         extra_query: vec![("orientation", "landscape".into())],
         server_aspect_param: None, // filtered client-side
+        page_param: "page",
+        page_base: 1,
     };
 
     let http = Arc::new(ReqwestFetch(client));
@@ -160,6 +162,8 @@ mod tests {
             block: BLOCK,
             extra_query: vec![("orientation", "landscape".into())],
             server_aspect_param: None,
+            page_param: "page",
+            page_base: 1,
         };
         RestSource::new(desc, http)
     }

--- a/muralis-source-pixabay/Cargo.toml
+++ b/muralis-source-pixabay/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "muralis-source-pixabay"
+edition.workspace = true
+version.workspace = true
+license.workspace = true
+
+[dependencies]
+muralis-core = { path = "../muralis-core" }
+muralis-source-common = { path = "../muralis-source-common" }
+reqwest = { workspace = true }
+serde = { workspace = true }
+toml = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }
+serde_json = { workspace = true }

--- a/muralis-source-pixabay/src/lib.rs
+++ b/muralis-source-pixabay/src/lib.rs
@@ -1,0 +1,315 @@
+use std::sync::Arc;
+
+use serde::Deserialize;
+
+use muralis_core::models::{SourceType, WallpaperPreview};
+use muralis_core::sources::{ContentSafety, SourceContext, WallpaperSource};
+use muralis_source_common::{
+    Auth, Descriptor, DetailResponse, ReqwestFetch, RestSource, SearchResponse,
+};
+
+/// Pixabay has a single endpoint; `base` + `search_path` reconstruct it.
+const API_BASE: &str = "https://pixabay.com";
+const API_PATH: &str = "/api/";
+/// Upstream pages consumed per logical page — Pixabay aspect filtering is
+/// client-side (Block B > 1), so over-fetch a few pages to fill a logical page.
+const BLOCK: u32 = 3;
+/// Pixabay's max `per_page` is 200; we request a healthy page to fill blocks.
+const PER_PAGE_CAP: u32 = 100;
+
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(default)]
+pub struct PixabayConfig {
+    pub enabled: bool,
+    pub api_key: Option<String>,
+}
+
+pub fn create_sources(
+    table: &toml::Table,
+    client: reqwest::Client,
+    ctx: &SourceContext,
+) -> Vec<Box<dyn WallpaperSource>> {
+    let Some(val) = table.get("pixabay") else {
+        return Vec::new();
+    };
+    let config: PixabayConfig = val.clone().try_into().unwrap_or_default();
+    if !config.enabled {
+        return Vec::new();
+    }
+    let Some(key) = config.api_key else {
+        return Vec::new();
+    };
+
+    let desc = Descriptor {
+        source_type: "pixabay",
+        display_name: "Pixabay",
+        base: API_BASE,
+        auth: Auth::QueryParam {
+            key: "key",
+            value: Some(key),
+        },
+        search_path: API_PATH,
+        detail_path: API_PATH,
+        query_key: "q",
+        per_page_param: Some("per_page"),
+        per_page_cap: PER_PAGE_CAP,
+        block: BLOCK,
+        extra_query: extra_query(ctx),
+        server_aspect_param: None, // Pixabay has no aspect param; filter client-side
+    };
+
+    let http = Arc::new(ReqwestFetch(client));
+    vec![Box::new(
+        RestSource::<PixabaySearchResponse, PixabayHit>::new(desc, http),
+    )]
+}
+
+/// Constant + context-driven query params:
+/// - `orientation=horizontal` — landscape server-side (like pexels/unsplash).
+/// - `safesearch` — driven by the global ceiling. Pixabay hosts no explicit
+///   tier (it self-caps at "moderate"), so the only meaningful distinction is
+///   safe vs. not. We enable safesearch only at the strictest ceiling
+///   (`Safe`); at `Moderate`/`Nsfw` we leave it off, since Pixabay cannot
+///   surface anything past its own moderate cap anyway.
+/// - `min_width`/`min_height` — pushed from the global `[filter]` (only Pixabay
+///   can do this server-side).
+fn extra_query(ctx: &SourceContext) -> Vec<(&'static str, String)> {
+    let safesearch = ctx.content_safety == ContentSafety::Safe;
+    vec![
+        ("orientation", "horizontal".into()),
+        ("safesearch", safesearch.to_string()),
+        ("min_width", ctx.min_width.to_string()),
+        ("min_height", ctx.min_height.to_string()),
+    ]
+}
+
+// -- API response types --
+
+#[derive(Debug, Deserialize)]
+pub struct PixabaySearchResponse {
+    hits: Vec<PixabayHit>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PixabayHit {
+    id: u64,
+    #[serde(rename = "pageURL")]
+    page_url: String,
+    #[serde(rename = "largeImageURL", default)]
+    large_image_url: String,
+    #[serde(rename = "fullHDURL", default)]
+    full_hd_url: String,
+    #[serde(rename = "imageURL", default)]
+    image_url: String,
+    #[serde(rename = "previewURL", default)]
+    preview_url: String,
+    #[serde(rename = "imageWidth")]
+    image_width: u32,
+    #[serde(rename = "imageHeight")]
+    image_height: u32,
+    #[serde(default)]
+    tags: String,
+}
+
+impl PixabayHit {
+    /// Pick the best available full-resolution URL. `imageURL` (full original)
+    /// is only present on the paid/full API tier; prefer it, then `fullHDURL`,
+    /// then `largeImageURL`.
+    fn full_url(&self) -> String {
+        for candidate in [&self.image_url, &self.full_hd_url, &self.large_image_url] {
+            if !candidate.is_empty() {
+                return candidate.clone();
+            }
+        }
+        self.preview_url.clone()
+    }
+}
+
+impl SearchResponse for PixabaySearchResponse {
+    fn into_previews(self, source_type: &str) -> Vec<WallpaperPreview> {
+        self.hits
+            .into_iter()
+            .map(|h| h.into_preview(source_type))
+            .collect()
+    }
+}
+
+impl DetailResponse for PixabayHit {
+    fn into_preview(self, source_type: &str) -> WallpaperPreview {
+        let full = self.full_url();
+        let thumb = if self.preview_url.is_empty() {
+            full.clone()
+        } else {
+            self.preview_url.clone()
+        };
+        let tags = self
+            .tags
+            .split(',')
+            .map(|t| t.trim().to_string())
+            .filter(|t| !t.is_empty())
+            .collect();
+        WallpaperPreview {
+            source_type: SourceType::new(source_type),
+            source_id: self.id.to_string(),
+            source_url: self.page_url,
+            thumbnail_url: thumb,
+            full_url: full,
+            width: self.image_width,
+            height: self.image_height,
+            tags,
+        }
+    }
+
+    /// Pixabay's detail lookup is a query-param id (`?id=N`), which the shared
+    /// engine's path-based `/{detail_path}/{id}` shape cannot express. Resolving
+    /// a Pixabay page URL into a preview is therefore unsupported in this slice;
+    /// return `None` so `favorites add` simply skips Pixabay rather than hitting
+    /// a malformed endpoint.
+    fn parse_id(_url: &str) -> Option<String> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use muralis_core::sources::AspectRatioFilter;
+    use muralis_source_common::testing::StubFetch;
+
+    const MOCK_RESPONSE: &str = r##"{
+        "total": 1,
+        "totalHits": 1,
+        "hits": [
+            {
+                "id": 195893,
+                "pageURL": "https://pixabay.com/photos/blossom-bloom-flower-195893/",
+                "previewURL": "https://cdn.pixabay.com/photo/2013/10/15/195893_150.jpg",
+                "largeImageURL": "https://pixabay.com/get/195893_1280.jpg",
+                "fullHDURL": "https://pixabay.com/get/195893_1920.jpg",
+                "imageURL": "https://pixabay.com/get/195893_orig.jpg",
+                "imageWidth": 4000,
+                "imageHeight": 2250,
+                "tags": "blossom, bloom, flower"
+            }
+        ]
+    }"##;
+
+    fn ctx() -> SourceContext {
+        SourceContext {
+            content_safety: ContentSafety::Safe,
+            min_width: 1920,
+            min_height: 1080,
+        }
+    }
+
+    fn source(
+        http: Arc<StubFetch>,
+        ctx: &SourceContext,
+    ) -> RestSource<PixabaySearchResponse, PixabayHit> {
+        let desc = Descriptor {
+            source_type: "pixabay",
+            display_name: "Pixabay",
+            base: API_BASE,
+            auth: Auth::QueryParam {
+                key: "key",
+                value: Some("RAWKEY".into()),
+            },
+            search_path: API_PATH,
+            detail_path: API_PATH,
+            query_key: "q",
+            per_page_param: Some("per_page"),
+            per_page_cap: PER_PAGE_CAP,
+            block: BLOCK,
+            extra_query: extra_query(ctx),
+            server_aspect_param: None,
+        };
+        RestSource::new(desc, http)
+    }
+
+    #[tokio::test]
+    async fn maps_envelope_to_preview() {
+        let http = Arc::new(StubFetch::ok_pages(&[
+            MOCK_RESPONSE,
+            r#"{"hits":[]}"#,
+            r#"{"hits":[]}"#,
+        ]));
+        let previews = source(http, &ctx())
+            .search("flowers", 1, 24, AspectRatioFilter::All)
+            .await
+            .unwrap();
+
+        assert_eq!(previews.len(), 1);
+        assert_eq!(previews[0].source_id, "195893");
+        assert_eq!(previews[0].width, 4000);
+        assert_eq!(previews[0].height, 2250);
+        // prefers imageURL (full original) for the wallpaper
+        assert_eq!(
+            previews[0].full_url,
+            "https://pixabay.com/get/195893_orig.jpg"
+        );
+        assert_eq!(
+            previews[0].source_url,
+            "https://pixabay.com/photos/blossom-bloom-flower-195893/"
+        );
+        assert_eq!(previews[0].tags, vec!["blossom", "bloom", "flower"]);
+    }
+
+    #[tokio::test]
+    async fn falls_back_to_full_hd_then_large_when_original_absent() {
+        let body = r#"{"hits":[{
+            "id": 1,
+            "pageURL": "https://pixabay.com/photos/x-1/",
+            "previewURL": "https://cdn.pixabay.com/photo/1_150.jpg",
+            "largeImageURL": "https://pixabay.com/get/1_1280.jpg",
+            "fullHDURL": "https://pixabay.com/get/1_1920.jpg",
+            "imageURL": "",
+            "imageWidth": 1920,
+            "imageHeight": 1080,
+            "tags": ""
+        }]}"#;
+        let http = Arc::new(StubFetch::ok(body));
+        let previews = source(http, &ctx())
+            .search("x", 1, 24, AspectRatioFilter::All)
+            .await
+            .unwrap();
+        assert_eq!(previews[0].full_url, "https://pixabay.com/get/1_1920.jpg");
+        assert!(previews[0].tags.is_empty());
+    }
+
+    #[tokio::test]
+    async fn search_sends_key_safesearch_orientation_and_min_dims() {
+        let http = Arc::new(StubFetch::ok(MOCK_RESPONSE));
+        source(http.clone(), &ctx())
+            .search("waves", 1, 24, AspectRatioFilter::All)
+            .await
+            .unwrap();
+
+        let call = http.last_call();
+        assert_eq!(call.url, "https://pixabay.com/api/");
+        assert_eq!(call.query_value("key"), Some("RAWKEY"));
+        assert_eq!(call.query_value("q"), Some("waves"));
+        assert_eq!(call.query_value("orientation"), Some("horizontal"));
+        assert_eq!(call.query_value("safesearch"), Some("true")); // Safe ceiling
+        assert_eq!(call.query_value("min_width"), Some("1920"));
+        assert_eq!(call.query_value("min_height"), Some("1080"));
+        assert_eq!(call.query_value("per_page"), Some("100"));
+    }
+
+    #[tokio::test]
+    async fn safesearch_off_when_ceiling_not_safe() {
+        let ctx = SourceContext {
+            content_safety: ContentSafety::Moderate,
+            min_width: 800,
+            min_height: 600,
+        };
+        let http = Arc::new(StubFetch::ok(MOCK_RESPONSE));
+        source(http.clone(), &ctx)
+            .search("x", 1, 24, AspectRatioFilter::All)
+            .await
+            .unwrap();
+
+        let call = http.last_call();
+        assert_eq!(call.query_value("safesearch"), Some("false"));
+        assert_eq!(call.query_value("min_width"), Some("800"));
+    }
+}

--- a/muralis-source-pixabay/src/lib.rs
+++ b/muralis-source-pixabay/src/lib.rs
@@ -57,6 +57,8 @@ pub fn create_sources(
         block: BLOCK,
         extra_query: extra_query(ctx),
         server_aspect_param: None, // Pixabay has no aspect param; filter client-side
+        page_param: "page",
+        page_base: 1,
     };
 
     let http = Arc::new(ReqwestFetch(client));
@@ -224,6 +226,8 @@ mod tests {
             block: BLOCK,
             extra_query: extra_query(ctx),
             server_aspect_param: None,
+            page_param: "page",
+            page_base: 1,
         };
         RestSource::new(desc, http)
     }

--- a/muralis-source-pixabay/src/lib.rs
+++ b/muralis-source-pixabay/src/lib.rs
@@ -41,8 +41,8 @@ pub fn create_sources(
     };
 
     let desc = Descriptor {
-        source_type: "pixabay",
-        display_name: "Pixabay",
+        source_type: "pixabay".into(),
+        display_name: "Pixabay".into(),
         base: API_BASE,
         auth: Auth::QueryParam {
             key: "key",
@@ -51,6 +51,7 @@ pub fn create_sources(
         search_path: API_PATH,
         detail_path: API_PATH,
         query_key: "q",
+        tag_prefix: None,
         per_page_param: Some("per_page"),
         per_page_cap: PER_PAGE_CAP,
         block: BLOCK,
@@ -207,8 +208,8 @@ mod tests {
         ctx: &SourceContext,
     ) -> RestSource<PixabaySearchResponse, PixabayHit> {
         let desc = Descriptor {
-            source_type: "pixabay",
-            display_name: "Pixabay",
+            source_type: "pixabay".into(),
+            display_name: "Pixabay".into(),
             base: API_BASE,
             auth: Auth::QueryParam {
                 key: "key",
@@ -217,6 +218,7 @@ mod tests {
             search_path: API_PATH,
             detail_path: API_PATH,
             query_key: "q",
+            tag_prefix: None,
             per_page_param: Some("per_page"),
             per_page_cap: PER_PAGE_CAP,
             block: BLOCK,

--- a/muralis-source-unsplash/src/lib.rs
+++ b/muralis-source-unsplash/src/lib.rs
@@ -53,6 +53,8 @@ pub fn create_sources(
         block: BLOCK,
         extra_query: vec![("orientation", "landscape".into())],
         server_aspect_param: None, // filtered client-side
+        page_param: "page",
+        page_base: 1,
     };
 
     let http = Arc::new(ReqwestFetch(client));
@@ -172,6 +174,8 @@ mod tests {
             block: BLOCK,
             extra_query: vec![("orientation", "landscape".into())],
             server_aspect_param: None,
+            page_param: "page",
+            page_base: 1,
         };
         RestSource::new(desc, http)
     }

--- a/muralis-source-unsplash/src/lib.rs
+++ b/muralis-source-unsplash/src/lib.rs
@@ -37,8 +37,8 @@ pub fn create_sources(
     };
 
     let desc = Descriptor {
-        source_type: "unsplash",
-        display_name: "Unsplash",
+        source_type: "unsplash".into(),
+        display_name: "Unsplash".into(),
         base: API_BASE,
         auth: Auth::Header {
             name: "Authorization",
@@ -47,6 +47,7 @@ pub fn create_sources(
         search_path: "/search/photos",
         detail_path: "/photos",
         query_key: "query",
+        tag_prefix: None,
         per_page_param: Some("per_page"),
         per_page_cap: 30,
         block: BLOCK,
@@ -155,8 +156,8 @@ mod tests {
 
     fn source(http: Arc<StubFetch>) -> RestSource<UnsplashSearchResponse, UnsplashPhoto> {
         let desc = Descriptor {
-            source_type: "unsplash",
-            display_name: "Unsplash",
+            source_type: "unsplash".into(),
+            display_name: "Unsplash".into(),
             base: API_BASE,
             auth: Auth::Header {
                 name: "Authorization",
@@ -165,6 +166,7 @@ mod tests {
             search_path: "/search/photos",
             detail_path: "/photos",
             query_key: "query",
+            tag_prefix: None,
             per_page_param: Some("per_page"),
             per_page_cap: 30,
             block: BLOCK,

--- a/muralis-source-unsplash/src/lib.rs
+++ b/muralis-source-unsplash/src/lib.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use serde::Deserialize;
 
 use muralis_core::models::{SourceType, WallpaperPreview};
-use muralis_core::sources::WallpaperSource;
+use muralis_core::sources::{SourceContext, WallpaperSource};
 use muralis_source_common::{
     Auth, Descriptor, DetailResponse, ReqwestFetch, RestSource, SearchResponse,
 };
@@ -23,6 +23,7 @@ pub struct UnsplashConfig {
 pub fn create_sources(
     table: &toml::Table,
     client: reqwest::Client,
+    _ctx: &SourceContext,
 ) -> Vec<Box<dyn WallpaperSource>> {
     let Some(val) = table.get("unsplash") else {
         return Vec::new();

--- a/muralis-source-wallhaven/src/lib.rs
+++ b/muralis-source-wallhaven/src/lib.rs
@@ -82,8 +82,8 @@ pub fn create_sources(
     let purity = effective_purity(&config.purity, ctx.content_safety);
 
     let desc = Descriptor {
-        source_type: "wallhaven",
-        display_name: "Wallhaven",
+        source_type: "wallhaven".into(),
+        display_name: "Wallhaven".into(),
         base: API_BASE,
         auth: Auth::QueryParam {
             key: "apikey",
@@ -92,6 +92,7 @@ pub fn create_sources(
         search_path: "/search",
         detail_path: "/w",
         query_key: "q",
+        tag_prefix: None,
         per_page_param: None, // wallhaven uses a fixed server page size
         per_page_cap: 24,
         block: 1, // server filters by aspect, so ~every result matches
@@ -203,8 +204,8 @@ mod tests {
 
     fn source(http: Arc<StubFetch>) -> RestSource<WallhavenResponse, WallhavenDetailResponse> {
         let desc = Descriptor {
-            source_type: "wallhaven",
-            display_name: "Wallhaven",
+            source_type: "wallhaven".into(),
+            display_name: "Wallhaven".into(),
             base: API_BASE,
             auth: Auth::QueryParam {
                 key: "apikey",
@@ -213,6 +214,7 @@ mod tests {
             search_path: "/search",
             detail_path: "/w",
             query_key: "q",
+            tag_prefix: None,
             per_page_param: None,
             per_page_cap: 24,
             block: 1,
@@ -274,8 +276,8 @@ mod tests {
         // send purity=100 to wallhaven — no NSFW leak.
         let clamped = effective_purity("111", ContentSafety::Safe);
         let desc = Descriptor {
-            source_type: "wallhaven",
-            display_name: "Wallhaven",
+            source_type: "wallhaven".into(),
+            display_name: "Wallhaven".into(),
             base: API_BASE,
             auth: Auth::QueryParam {
                 key: "apikey",
@@ -284,6 +286,7 @@ mod tests {
             search_path: "/search",
             detail_path: "/w",
             query_key: "q",
+            tag_prefix: None,
             per_page_param: None,
             per_page_cap: 24,
             block: 1,

--- a/muralis-source-wallhaven/src/lib.rs
+++ b/muralis-source-wallhaven/src/lib.rs
@@ -3,12 +3,48 @@ use std::sync::Arc;
 use serde::Deserialize;
 
 use muralis_core::models::{SourceType, WallpaperPreview};
-use muralis_core::sources::WallpaperSource;
+use muralis_core::sources::{ContentSafety, SourceContext, WallpaperSource};
 use muralis_source_common::{
     Auth, Descriptor, DetailResponse, ReqwestFetch, RestSource, SearchResponse,
 };
 
 const API_BASE: &str = "https://wallhaven.cc/api/v1";
+
+/// Map the global content-safety ceiling onto wallhaven's 3-bit `purity`
+/// string (SFW / Sketchy / NSFW). The ceiling is a *cap*: we bitwise-AND the
+/// configured purity with the ceiling's allowed bits, so per-source config can
+/// only tighten below the ceiling, never loosen past it (ADR 0002). A stale
+/// `purity="111"` under global `safe` clamps to `100` (SFW only) — no NSFW leak.
+fn effective_purity(configured: &str, ceiling: ContentSafety) -> String {
+    let cap = match ceiling {
+        ContentSafety::Safe => 0b100,
+        ContentSafety::Moderate => 0b110,
+        ContentSafety::Nsfw => 0b111,
+    };
+    let cfg = parse_purity_bits(configured);
+    let bits = cfg & cap;
+    // Never emit an all-zero purity (wallhaven would reject it); fall back to
+    // SFW-only, which is always within any ceiling.
+    let bits = if bits == 0 { 0b100 } else { bits };
+    format!("{}{}{}", (bits >> 2) & 1, (bits >> 1) & 1, bits & 1)
+}
+
+/// Parse a wallhaven purity string ("100", "110", …) into a 3-bit mask. Any
+/// non-`"1"`/`"0"` char is treated as `0`; short/long strings are tolerated by
+/// reading at most the first three chars. Defaults to SFW-only on garbage.
+fn parse_purity_bits(s: &str) -> u8 {
+    let mut bits = 0u8;
+    for (i, c) in s.chars().take(3).enumerate() {
+        if c == '1' {
+            bits |= 1 << (2 - i);
+        }
+    }
+    if bits == 0 {
+        0b100
+    } else {
+        bits
+    }
+}
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
@@ -33,6 +69,7 @@ impl Default for WallhavenConfig {
 pub fn create_sources(
     table: &toml::Table,
     client: reqwest::Client,
+    ctx: &SourceContext,
 ) -> Vec<Box<dyn WallpaperSource>> {
     let Some(val) = table.get("wallhaven") else {
         return Vec::new();
@@ -41,6 +78,8 @@ pub fn create_sources(
     if !config.enabled {
         return Vec::new();
     }
+
+    let purity = effective_purity(&config.purity, ctx.content_safety);
 
     let desc = Descriptor {
         source_type: "wallhaven",
@@ -56,7 +95,7 @@ pub fn create_sources(
         per_page_param: None, // wallhaven uses a fixed server page size
         per_page_cap: 24,
         block: 1, // server filters by aspect, so ~every result matches
-        extra_query: vec![("categories", config.categories), ("purity", config.purity)],
+        extra_query: vec![("categories", config.categories), ("purity", purity)],
         server_aspect_param: Some("ratios"),
     };
 
@@ -211,6 +250,55 @@ mod tests {
         assert_eq!(call.query_value("categories"), Some("100"));
         assert_eq!(call.query_value("ratios"), Some("16x9"));
         assert_eq!(call.query_value("per_page"), None); // not sent for wallhaven
+    }
+
+    #[test]
+    fn effective_purity_clamps_to_ceiling() {
+        // global safe forces SFW-only regardless of a stale config purity
+        assert_eq!(effective_purity("111", ContentSafety::Safe), "100");
+        assert_eq!(effective_purity("110", ContentSafety::Safe), "100");
+        // moderate allows up to sketchy, strips NSFW bit
+        assert_eq!(effective_purity("111", ContentSafety::Moderate), "110");
+        // nsfw lets the configured purity through unchanged
+        assert_eq!(effective_purity("111", ContentSafety::Nsfw), "111");
+        // config can still tighten below the ceiling
+        assert_eq!(effective_purity("100", ContentSafety::Nsfw), "100");
+        // garbage / empty config falls back to SFW-only
+        assert_eq!(effective_purity("", ContentSafety::Nsfw), "100");
+        assert_eq!(effective_purity("000", ContentSafety::Nsfw), "100");
+    }
+
+    #[tokio::test]
+    async fn search_request_uses_clamped_purity_under_safe_ceiling() {
+        // a source whose purity was clamped by the global `safe` ceiling must
+        // send purity=100 to wallhaven — no NSFW leak.
+        let clamped = effective_purity("111", ContentSafety::Safe);
+        let desc = Descriptor {
+            source_type: "wallhaven",
+            display_name: "Wallhaven",
+            base: API_BASE,
+            auth: Auth::QueryParam {
+                key: "apikey",
+                value: Some("KEY".into()),
+            },
+            search_path: "/search",
+            detail_path: "/w",
+            query_key: "q",
+            per_page_param: None,
+            per_page_cap: 24,
+            block: 1,
+            extra_query: vec![("categories", "100".into()), ("purity", clamped)],
+            server_aspect_param: Some("ratios"),
+        };
+        let http = Arc::new(StubFetch::ok(MOCK_RESPONSE));
+        let src: RestSource<WallhavenResponse, WallhavenDetailResponse> =
+            RestSource::new(desc, http.clone());
+
+        src.search("x", 1, 24, AspectRatioFilter::All)
+            .await
+            .unwrap();
+
+        assert_eq!(http.last_call().query_value("purity"), Some("100"));
     }
 
     #[test]

--- a/muralis-source-wallhaven/src/lib.rs
+++ b/muralis-source-wallhaven/src/lib.rs
@@ -98,6 +98,8 @@ pub fn create_sources(
         block: 1, // server filters by aspect, so ~every result matches
         extra_query: vec![("categories", config.categories), ("purity", purity)],
         server_aspect_param: Some("ratios"),
+        page_param: "page",
+        page_base: 1,
     };
 
     let http = Arc::new(ReqwestFetch(client));
@@ -220,6 +222,8 @@ mod tests {
             block: 1,
             extra_query: vec![("categories", "100".into()), ("purity", "100".into())],
             server_aspect_param: Some("ratios"),
+            page_param: "page",
+            page_base: 1,
         };
         RestSource::new(desc, http)
     }
@@ -292,6 +296,8 @@ mod tests {
             block: 1,
             extra_query: vec![("categories", "100".into()), ("purity", clamped)],
             server_aspect_param: Some("ratios"),
+            page_param: "page",
+            page_base: 1,
         };
         let http = Arc::new(StubFetch::ok(MOCK_RESPONSE));
         let src: RestSource<WallhavenResponse, WallhavenDetailResponse> =


### PR DESCRIPTION
## Summary
Adds two new wallpaper sources and a global content-safety ceiling that all NSFW-capable sources must honor.

- **Pixabay source** (`muralis-source-pixabay`) — paged JSON REST source.
- **Booru multi-host source** (`muralis-source-booru`) — one crate, many hosts via `[[sources.booru]]`; `flavor` selects API dialect (danbooru/moebooru/gelbooru).
- **Global content-safety ceiling** — `SourceContext` carries `content_safety` + `min_width`/`min_height`; sources can only tighten within the ceiling, never loosen past it.
- Wired existing sources (wallhaven/unsplash/pexels/feed) through the new `SourceContext`.

## Docs
- Sources guide + Reddit-as-feed recipe in README.
- Design captured in `CONTEXT.md` glossary + `docs/adr/0001-0002`.
- `assets/demo-config.toml` examples (incl. rule34 multi-host).

## Test plan
- `cargo test --workspace`
- `cargo clippy --workspace -- -D warnings`
- `cargo fmt --all -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)