### PR TITLE
DMS widget v1, and the IPC contract it needs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -100,20 +100,28 @@ word stays reserved for a source crate, so the directory and all our prose say
 _Avoid_: DMS plugin, wallpaper tab (it replaced one; it is not one)
 
 **Consumer**:
-Anything outside the workspace that drives muralis through the **CLI contract**
+Anything outside the workspace that drives muralis through the **IPC contract**
 rather than linking `muralis-core`. The **DMS Widget** is the first. A Consumer
-is a client of the contract and never a **Source**.
+is a client of the contract and never a **Source**. Consumers are not the
+audience for the **CLI contract** — that seam serves scripts, keybinds and
+humans.
+
+**IPC contract**:
+The daemon socket protocol a **Consumer** depends on: the `IpcRequest` /
+`IpcResponse` variants and the event stream a subscriber holds open. Being a
+contract is what distinguishes it from the daemon's internals — variant names
+and response field names are a compatibility promise, not free to churn. It
+carries two shapes: request/response, and a subscription the Consumer keeps
+open and reconnects to.
+_Avoid_: API (reserve for a remote **Source**'s HTTP API)
 
 **CLI contract**:
-The subset of `muralis` CLI commands and their JSON output that a **Consumer**
-depends on — favorites listing, daemon status, set/next/prev/pause/resume/mode,
-and the streaming `subscribe`. Being a contract is what distinguishes it from
-the rest of the CLI surface: its command names and output field names are a
-compatibility promise to Consumers, not an implementation detail free to churn.
-It carries two shapes, not one — request/response commands that exit, and
-streaming commands a Consumer holds open and must reconnect to.
-_Avoid_: API (reserve for a remote **Source**'s HTTP API), IPC (that is the
-daemon socket, a different seam)
+The subset of `muralis` CLI commands and their JSON output that scripts,
+keybinds and humans depend on. Distinct from the **IPC contract** in audience,
+not just in wire format: the CLI keeps promises the IPC contract does not, such
+as `favorites list` answering from the database with the daemon down. A
+**Consumer** does not use it.
+_Avoid_: API, treating it as the Consumer seam (that is the **IPC contract**)
 
 ## Relationships
 
@@ -124,7 +132,7 @@ daemon socket, a different seam)
 - `create_sources` takes a **SourceContext** (global cross-cutting knobs: **Content Safety policy**, `min_width`/`min_height`) in addition to the `[sources]` table + client. The contract is the same for every plugin.
 - A gelbooru **Flavor** instance points at any gelbooru-clone host by `base` (gelbooru, rule34, safebooru, realbooru) — multi-host for free.
 - A **Preview** becomes a **Wallpaper** when kept; the **Library** is every Wallpaper. Nothing distinguishes Wallpapers within the Library — there is no favorite flag.
-- A **Consumer** (e.g. the **DMS Widget**) depends only on the **CLI contract**; it never links `muralis-core` and never registers as a **Source**.
+- A **Consumer** (e.g. the **DMS Widget**) depends only on the **IPC contract**; it never links `muralis-core` and never registers as a **Source**.
 
 ## Example dialogue
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -90,10 +90,12 @@ is a client of the contract and never a **Source**.
 
 **CLI contract**:
 The subset of `muralis` CLI commands and their JSON output that a **Consumer**
-depends on — favorites listing, daemon status, set/next/prev/pause/resume/mode.
-Being a contract is what distinguishes it from the rest of the CLI surface:
-its command names and output field names are a compatibility promise to
-Consumers, not an implementation detail free to churn.
+depends on — favorites listing, daemon status, set/next/prev/pause/resume/mode,
+and the streaming `subscribe`. Being a contract is what distinguishes it from
+the rest of the CLI surface: its command names and output field names are a
+compatibility promise to Consumers, not an implementation detail free to churn.
+It carries two shapes, not one — request/response commands that exit, and
+streaming commands a Consumer holds open and must reconnect to.
 _Avoid_: API (reserve for a remote **Source**'s HTTP API), IPC (that is the
 daemon socket, a different seam)
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -72,6 +72,31 @@ The fixed number of upstream API pages a **RestSource** maps to one logical page
 The transport seam behind **RestSource**, at bytes level: `get(url, headers, query) -> (StatusCode, Bytes)`. Lives in `muralis-source-common`. The real adapter wraps `reqwest`; the test adapter returns canned bytes and asserts the auth header and pagination params. Auth injection and JSON parsing live in **RestSource**, not behind this seam.
 _Avoid_: HttpClient, Transport, Fetcher
 
+### Consumers
+
+**DMS Widget**:
+The DankBar surface (in `dms-widget/`) that drives muralis from
+DankMaterialShell — a **Consumer**, not a **Source**. It adds no wallpapers; it
+reads favorites and drives rotation through the CLI. DMS's own vocabulary calls
+this a *plugin* (`plugin.json`, `dms plugins install`); inside this repo that
+word stays reserved for a source crate, so the directory and all our prose say
+*widget*.
+_Avoid_: DMS plugin, wallpaper tab (it replaced one; it is not one)
+
+**Consumer**:
+Anything outside the workspace that drives muralis through the **CLI contract**
+rather than linking `muralis-core`. The **DMS Widget** is the first. A Consumer
+is a client of the contract and never a **Source**.
+
+**CLI contract**:
+The subset of `muralis` CLI commands and their JSON output that a **Consumer**
+depends on — favorites listing, daemon status, set/next/prev/pause/resume/mode.
+Being a contract is what distinguishes it from the rest of the CLI surface:
+its command names and output field names are a compatibility promise to
+Consumers, not an implementation detail free to churn.
+_Avoid_: API (reserve for a remote **Source**'s HTTP API), IPC (that is the
+daemon socket, a different seam)
+
 ## Relationships
 
 - A **RestSource** is built from exactly one **Source Descriptor** and one **HttpFetch** adapter.
@@ -80,6 +105,7 @@ _Avoid_: HttpClient, Transport, Fetcher
 - The `SourceRegistry` holds **Sources** (any mix of **RestSource**, **Booru Source**, **Pixabay Source**, **Feed Source**).
 - `create_sources` takes a **SourceContext** (global cross-cutting knobs: **Content Safety policy**, `min_width`/`min_height`) in addition to the `[sources]` table + client. The contract is the same for every plugin.
 - A gelbooru **Flavor** instance points at any gelbooru-clone host by `base` (gelbooru, rule34, safebooru, realbooru) — multi-host for free.
+- A **Consumer** (e.g. the **DMS Widget**) depends only on the **CLI contract**; it never links `muralis-core` and never registers as a **Source**.
 
 ## Example dialogue
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -88,6 +88,31 @@ The fixed number of upstream API pages a **RestSource** maps to one logical page
 The transport seam behind **RestSource**, at bytes level: `get(url, headers, query) -> (StatusCode, Bytes)`. Lives in `muralis-source-common`. The real adapter wraps `reqwest`; the test adapter returns canned bytes and asserts the auth header and pagination params. Auth injection and JSON parsing live in **RestSource**, not behind this seam.
 _Avoid_: HttpClient, Transport, Fetcher
 
+### Display
+
+**Backend**:
+The thing that puts a **Wallpaper** on screen, implementing `WallpaperBackend`
+(`set_wallpaper`, `set_wallpaper_all`, `is_ready`). Each one drives a separate
+long-running process of its own — awww-daemon, hyprpaper — which muralis does
+not start and cannot assume is up.
+_Avoid_: renderer, compositor (that is Hyprland), swww (that is one backend's
+binary, and it is now named awww)
+
+**Readiness probe**:
+A **Backend** answering whether its process is accepting requests yet
+(`awww query`, `hyprctl hyprpaper listactive`). Exists because the compositor
+launches muralis and the backend together with no sequencing: the `random_startup`
+apply is the only one of the session, so firing it into an unbound socket costs
+the whole session's wallpaper. The daemon probes with bounded backoff
+(`ReadinessPolicy`) before that apply, and only then.
+_Avoid_: health check (it gates one apply, it does not monitor)
+
+**last_error**:
+The `DaemonStatus` field carrying why the last apply failed, cleared by the next
+success. A backend failure used to be a `warn!` on a stderr nobody captures; this
+is the same fact on the **IPC contract**, so a **Consumer** can show a wrong
+screen as wrong.
+
 ### Consumers
 
 **DMS Widget**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -113,6 +113,15 @@ success. A backend failure used to be a `warn!` on a stderr nobody captures; thi
 is the same fact on the **IPC contract**, so a **Consumer** can show a wrong
 screen as wrong.
 
+**Current wallpaper**:
+What is actually on screen, held by the daemon as the whole `Wallpaper` row
+rather than its id. One function writes it (`DisplayEngine::set_current`), and
+writing it is what clears **last_error** and emits a **Daemon event** — so a
+timed rotation, a `SetWallpaper` and a workspace switch cannot disagree about
+what "current" means or about who gets told. It had three independent
+assignment sites before, and only two of them cleared the error.
+_Avoid_: current_index (that is the rotation cursor, not what is displayed)
+
 **Mode viability**:
 Whether a display mode (`DisplayMode`) has the config it needs to do anything —
 `schedule` needs at least one entry in `schedules`, `workspace` at least one in
@@ -159,12 +168,44 @@ humans.
 
 **IPC contract**:
 The daemon socket protocol a **Consumer** depends on: the `IpcRequest` /
-`IpcResponse` variants and the event stream a subscriber holds open. Being a
-contract is what distinguishes it from the daemon's internals — variant names
+`IpcResponse` variants and the **Daemon events** a subscriber holds open. Being
+a contract is what distinguishes it from the daemon's internals — variant names
 and response field names are a compatibility promise, not free to churn. It
-carries two shapes: request/response, and a subscription the Consumer keeps
+carries two shapes: request/response, and a **Subscription** the Consumer keeps
 open and reconnects to.
 _Avoid_: API (reserve for a remote **Source**'s HTTP API)
+
+**Subscription**:
+A **Consumer**'s `Subscribe` connection, held open while the daemon writes
+**Daemon events** to it. The one request that gets no `IpcResponse` — the first
+lines back are a **Snapshot**, and everything after is live. It exists because
+the daemon cannot otherwise push: a timed rotation left the DMS Widget's matugen
+palette matching a wallpaper that was no longer on screen, resyncing only when
+the user happened to open the popout.
+_Avoid_: watch, listener, poll (the point is that it is not polling)
+
+**Daemon event**:
+One line of a **Subscription**: `{"event": …}`, tagged the way `IpcRequest` is
+tagged `command`, so a Consumer switches on one field. Three kinds:
+`wallpaper_changed` (carrying the whole `Wallpaper` row), `mode_changed`,
+`pause_changed`. An event is self-sufficient by design — `wallpaper_changed`
+holds `file_path` because `SessionData.setWallpaper()` takes a path, and an
+event a Consumer must chase with a `Status` is not a push. Adding a kind is
+backwards-compatible; changing a shipped one is not. `wallpaper_changed` fires
+only on a *successful* apply: a Consumer regenerates a whole palette from what
+it is told, so announcing an image nobody can see is worse than announcing
+nothing.
+_Avoid_: message, notification, signal
+
+**Snapshot**:
+The daemon's current state rendered as the **Daemon events** that would have
+produced it, written first on every **Subscription** and again after a lagging
+subscriber is resynced. Without it a Consumer learns nothing until the next
+rotation, and a reconnect after a `DankSocket` backoff would silently miss
+whatever changed while it was away — which is exactly the defect a subscription
+exists to fix.
+_Avoid_: initial state, replay (nothing is replayed — it is current state, not
+history)
 
 **Favorites request**:
 The **IPC contract**'s read of the **Library**: `Favorites { offset, limit }`,
@@ -198,6 +239,12 @@ _Avoid_: API, treating it as the Consumer seam (that is the **IPC contract**)
 - A **Preview** becomes a **Wallpaper** when kept; the **Library** is every Wallpaper. Nothing distinguishes Wallpapers within the Library — there is no favorite flag.
 - A **Consumer** (e.g. the **DMS Widget**) depends only on the **IPC contract**; it never links `muralis-core` and never registers as a **Source**.
 - The **Library** has exactly one backing store behind both seams: the daemon answers the **Favorites request** from the database, and `favorites list` falls back to that same database only when the daemon cannot answer.
+- Every **Daemon event** originates inside the daemon: a **Current wallpaper**
+  write, a `SetMode` that took effect, or a pause toggle. A **Consumer** never
+  emits one.
+- A **Subscription** begins with a **Snapshot**, so a Consumer's state is a
+  function of the connection alone — it never needs a `Status` round-trip to
+  become current.
 - A **Mode write-through** precedes the mode taking effect, so a refused or
   unwritable config leaves the daemon on the mode it already had.
 - **Mode viability** is read from the `Config` alone — never from the daemon's running state — so `SetMode` and `status` cannot disagree about which modes are usable.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -125,6 +125,18 @@ refusal and the offer drift apart.
 _Avoid_: valid mode (a mode is well-formed either way; it is the config that is
 missing), enabled
 
+**Mode write-through**:
+A `SetMode` landing in `config.toml` before it takes effect
+(`Config::persist_mode`), so the running mode and the one the next daemon boots
+into cannot disagree. The edit is surgical — only the `mode` value moves, and the
+comments and spacing of a hand-written config survive — and a file that will not
+parse is refused rather than overwritten. A write that fails fails the command:
+a mode that works now and silently reverts at reboot is the thing being avoided.
+Pause is deliberately *not* written through; pausing rotation reads as temporary
+in a way that choosing a mode does not.
+_Avoid_: save (`Config::save` reserialized the whole file and took the comments
+with it; it is gone), autosave, sync
+
 ### Consumers
 
 **DMS Widget**:
@@ -170,6 +182,8 @@ _Avoid_: API, treating it as the Consumer seam (that is the **IPC contract**)
 - A gelbooru **Flavor** instance points at any gelbooru-clone host by `base` (gelbooru, rule34, safebooru, realbooru) — multi-host for free.
 - A **Preview** becomes a **Wallpaper** when kept; the **Library** is every Wallpaper. Nothing distinguishes Wallpapers within the Library — there is no favorite flag.
 - A **Consumer** (e.g. the **DMS Widget**) depends only on the **IPC contract**; it never links `muralis-core` and never registers as a **Source**.
+- A **Mode write-through** precedes the mode taking effect, so a refused or
+  unwritable config leaves the daemon on the mode it already had.
 - **Mode viability** is read from the `Config` alone — never from the daemon's running state — so `SetMode` and `status` cannot disagree about which modes are usable.
 
 ## Example dialogue

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -113,6 +113,18 @@ success. A backend failure used to be a `warn!` on a stderr nobody captures; thi
 is the same fact on the **IPC contract**, so a **Consumer** can show a wrong
 screen as wrong.
 
+**Mode viability**:
+Whether a display mode (`DisplayMode`) has the config it needs to do anything —
+`schedule` needs at least one entry in `schedules`, `workspace` at least one in
+`workspaces`; the four rotation modes need nothing. One predicate
+(`Config::mode_unavailable_reason`) answers it, returning the reason a mode
+cannot run. `SetMode` refuses on a reason instead of accepting a mode whose
+handler would no-op forever, and the usable set a **Consumer** reads off
+`status` is derived from the same call — encoding the rule twice is how the
+refusal and the offer drift apart.
+_Avoid_: valid mode (a mode is well-formed either way; it is the config that is
+missing), enabled
+
 ### Consumers
 
 **DMS Widget**:
@@ -158,6 +170,7 @@ _Avoid_: API, treating it as the Consumer seam (that is the **IPC contract**)
 - A gelbooru **Flavor** instance points at any gelbooru-clone host by `base` (gelbooru, rule34, safebooru, realbooru) — multi-host for free.
 - A **Preview** becomes a **Wallpaper** when kept; the **Library** is every Wallpaper. Nothing distinguishes Wallpapers within the Library — there is no favorite flag.
 - A **Consumer** (e.g. the **DMS Widget**) depends only on the **IPC contract**; it never links `muralis-core` and never registers as a **Source**.
+- **Mode viability** is read from the `Config` alone — never from the daemon's running state — so `SetMode` and `status` cannot disagree about which modes are usable.
 
 ## Example dialogue
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -56,8 +56,24 @@ The policy is an **ordered level** — `safe` < `moderate` < `nsfw` — acting a
 ### Search & paging
 
 **Preview**:
-A transient search result (`WallpaperPreview`) — not yet favorited, not on disk.
+A transient search result (`WallpaperPreview`) — not in the **Library**, not on
+disk.
 _Avoid_: result, thumbnail, image
+
+**Wallpaper**:
+A **Preview** that has been kept: downloaded to disk and recorded as a row in
+`wallpapers`. The persisted counterpart to a Preview, carrying usage history
+(`last_used`, `use_count`) a Preview has no place for.
+_Avoid_: favorite (see **Library**), image, file
+
+**Library**:
+Every **Wallpaper** on disk — the set the daemon rotates through and a
+**Consumer** displays. There is no curated subset within it: the schema has no
+favorite flag, so being in the Library *is* being kept, and `muralis favorites
+list` returns the whole thing. The CLI spelling is historical and stays (it is
+part of the **CLI contract**); our own prose says Library, so nothing implies a
+filter that does not exist.
+_Avoid_: favorites (the command name, not the concept), collection, gallery
 
 **Page-filling**:
 A **RestSource** consuming a fixed block of B upstream API pages for one logical page, applying the aspect filter as it goes, returning up to `per_page` matches. Best-effort *within the block*: a logical page may return fewer than `per_page` even when more matches exist upstream.
@@ -107,6 +123,7 @@ daemon socket, a different seam)
 - The `SourceRegistry` holds **Sources** (any mix of **RestSource**, **Booru Source**, **Pixabay Source**, **Feed Source**).
 - `create_sources` takes a **SourceContext** (global cross-cutting knobs: **Content Safety policy**, `min_width`/`min_height`) in addition to the `[sources]` table + client. The contract is the same for every plugin.
 - A gelbooru **Flavor** instance points at any gelbooru-clone host by `base` (gelbooru, rule34, safebooru, realbooru) — multi-host for free.
+- A **Preview** becomes a **Wallpaper** when kept; the **Library** is every Wallpaper. Nothing distinguishes Wallpapers within the Library — there is no favorite flag.
 - A **Consumer** (e.g. the **DMS Widget**) depends only on the **CLI contract**; it never links `muralis-core` and never registers as a **Source**.
 
 ## Example dialogue

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -120,8 +120,10 @@ Whether a display mode (`DisplayMode`) has the config it needs to do anything �
 (`Config::mode_unavailable_reason`) answers it, returning the reason a mode
 cannot run. `SetMode` refuses on a reason instead of accepting a mode whose
 handler would no-op forever, and the usable set a **Consumer** reads off
-`status` is derived from the same call — encoding the rule twice is how the
-refusal and the offer drift apart.
+`status` (`DaemonStatus::available_modes`, built by `Config::available_modes`
+as the modes answering `None`) is derived from the same call — encoding the
+rule twice is how the refusal and the offer drift apart. The reason itself
+stays on the refusal; `status` carries the set, not the prose.
 _Avoid_: valid mode (a mode is well-formed either way; it is the config that is
 missing), enabled
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -164,6 +164,19 @@ carries two shapes: request/response, and a subscription the Consumer keeps
 open and reconnects to.
 _Avoid_: API (reserve for a remote **Source**'s HTTP API)
 
+**Favorites request**:
+The **IPC contract**'s read of the **Library**: `Favorites { offset, limit }`,
+answered with a `FavoritesPage` (`wallpapers`, `total`, `offset`). Both bounds
+are optional and a bare `favorites` means the whole Library — the **CLI
+contract**'s shape — while a **Consumer** drawing a grid asks for the window it
+draws. Paging is on the wire because the numbers say so: a **Wallpaper** row is
+~445 B of JSON, so a 1000-wallpaper Library is a ~435 KiB single socket line
+against ~7 KiB for a 16-item page. The daemon reads the database per request
+rather than serving its rotation cache, because `favorites add` writes the store
+behind the daemon's back and a Consumer must see the wallpaper it just kept.
+_Avoid_: library request (the command name is `Favorites`, historical like the
+CLI's), listFavorites
+
 **CLI contract**:
 The subset of `muralis` CLI commands and their JSON output that scripts,
 keybinds and humans depend on. Distinct from the **IPC contract** in audience,
@@ -182,6 +195,7 @@ _Avoid_: API, treating it as the Consumer seam (that is the **IPC contract**)
 - A gelbooru **Flavor** instance points at any gelbooru-clone host by `base` (gelbooru, rule34, safebooru, realbooru) — multi-host for free.
 - A **Preview** becomes a **Wallpaper** when kept; the **Library** is every Wallpaper. Nothing distinguishes Wallpapers within the Library — there is no favorite flag.
 - A **Consumer** (e.g. the **DMS Widget**) depends only on the **IPC contract**; it never links `muralis-core` and never registers as a **Source**.
+- The **Library** has exactly one backing store behind both seams: the daemon answers the **Favorites request** from the database, and `favorites list` falls back to that same database only when the daemon cannot answer.
 - A **Mode write-through** precedes the mode taking effect, so a refused or
   unwritable config leaves the daemon on the mode it already had.
 - **Mode viability** is read from the `Config` alone — never from the daemon's running state — so `SetMode` and `status` cannot disagree about which modes are usable.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1657,12 +1657,14 @@ name = "muralis-daemon"
 version = "0.2.4"
 dependencies = [
  "anyhow",
+ "async-trait",
  "chrono",
  "futures-lite",
  "hyprland",
  "muralis-core",
  "rand 0.9.2",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1649,6 +1649,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml",
+ "toml_edit",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ license = "MIT"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
+toml_edit = "0.22"
 tokio = { version = "1", features = ["full"] }
 async-trait = "0.1"
 reqwest = { version = "0.12", features = ["json", "native-tls"] }

--- a/dms-widget/MuralisPopout.qml
+++ b/dms-widget/MuralisPopout.qml
@@ -1,0 +1,378 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import qs.Common
+import qs.Widgets
+import qs.Modules.Plugins
+
+// The popout: a page of the Library, transport, and the mode switcher.
+//
+// A pure view over MuralisWidget's state. It owns no socket and caches
+// nothing — everything it draws is a property of `widget`, so a rotation
+// arriving over the subscription redraws this without it asking.
+PopoutComponent {
+    id: popout
+
+    // The MuralisWidget root.
+    property var widget: null
+
+    readonly property int columns: 4
+    readonly property real cellWidth: (width - (columns - 1) * Theme.spacingS) / columns
+    readonly property real cellHeight: Math.round(cellWidth * 9 / 16)
+
+    spacing: Theme.spacingS
+
+    headerText: "Muralis"
+    detailsText: {
+        if (!widget)
+            return ""
+        if (!widget.daemonUp)
+            return "Daemon not running"
+        const count = widget.wallpaperCount + (widget.wallpaperCount === 1 ? " wallpaper" : " wallpapers")
+        return widget.modeLabel(widget.mode) + (widget.paused ? " · paused" : "") + " · " + count
+    }
+    showCloseButton: true
+
+    headerActions: Component {
+        DankActionButton {
+            iconName: "refresh"
+            iconSize: Theme.iconSize - 6
+            enabled: popout.widget && popout.widget.daemonUp
+            opacity: enabled ? 1 : 0.4
+            tooltipText: "Reload the library"
+            onClicked: {
+                if (popout.widget)
+                    popout.widget.refresh()
+            }
+        }
+    }
+
+    // --- Failure states ---------------------------------------------------
+    //
+    // Three of the four states in the README are rendered rather than hidden.
+    // The fourth — muralis not installed — never gets this far, because
+    // StartupCheck.qml blocks activation.
+
+    StyledRect {
+        width: parent.width
+        height: visible ? bannerColumn.implicitHeight + Theme.spacingM * 2 : 0
+        visible: bannerTitle.text !== ""
+        radius: Theme.cornerRadius
+        color: Theme.withAlpha(bannerIcon.color, 0.12)
+
+        Row {
+            anchors.fill: parent
+            anchors.margins: Theme.spacingM
+            spacing: Theme.spacingS
+
+            DankIcon {
+                id: bannerIcon
+                anchors.verticalCenter: parent.verticalCenter
+                size: Theme.iconSize - 2
+                name: {
+                    if (!popout.widget || !popout.widget.daemonUp)
+                        return "cloud_off"
+                    if (popout.widget.libraryEmpty)
+                        return "photo_library"
+                    return "info"
+                }
+                color: {
+                    if (!popout.widget || !popout.widget.daemonUp)
+                        return Theme.error
+                    if (popout.widget.libraryEmpty)
+                        return Theme.surfaceVariantText
+                    return Theme.warning
+                }
+            }
+
+            Column {
+                id: bannerColumn
+                width: parent.width - bannerIcon.width - Theme.spacingS
+                anchors.verticalCenter: parent.verticalCenter
+                spacing: 2
+
+                StyledText {
+                    id: bannerTitle
+                    width: parent.width
+                    wrapMode: Text.WordWrap
+                    font.pixelSize: Theme.fontSizeMedium
+                    font.weight: Font.DemiBold
+                    color: Theme.surfaceText
+                    text: {
+                        if (!popout.widget)
+                            return ""
+                        if (!popout.widget.daemonUp)
+                            return "muralis is not running"
+                        if (popout.widget.libraryEmpty)
+                            return "The library is empty"
+                        if (popout.widget.nothingApplied)
+                            return "No wallpaper applied this session"
+                        return ""
+                    }
+                }
+
+                StyledText {
+                    width: parent.width
+                    wrapMode: Text.WordWrap
+                    font.pixelSize: Theme.fontSizeSmall
+                    color: Theme.surfaceVariantText
+                    visible: text !== ""
+                    text: {
+                        if (!popout.widget)
+                            return ""
+                        if (!popout.widget.daemonUp)
+                            return "The library lives behind the same socket, so there is nothing to show until the daemon is back. Start it with muralis-daemon."
+                        if (popout.widget.libraryEmpty)
+                            return "Find wallpapers with muralis search, then keep one with muralis favorites add."
+                        if (popout.widget.nothingApplied)
+                            return popout.widget.lastError !== ""
+                            ? "The last apply failed: " + popout.widget.lastError
+                            : "The daemon has applied nothing so far. Picking one below fixes it."
+                        return ""
+                    }
+                }
+            }
+        }
+    }
+
+    // --- Library grid -----------------------------------------------------
+
+    Grid {
+        width: parent.width
+        columns: popout.columns
+        spacing: Theme.spacingS
+        visible: popout.widget && popout.widget.daemonUp && popout.widget.library.length > 0
+        // Dimmed rather than emptied while a page is in flight: a grid that
+        // blanks on every page turn reads as a failure.
+        opacity: popout.widget && popout.widget.libraryLoading ? 0.5 : 1
+
+        Repeater {
+            model: popout.widget ? popout.widget.library : []
+
+            StyledRect {
+                id: cell
+                width: popout.cellWidth
+                height: popout.cellHeight
+                radius: Theme.cornerRadius
+                color: Theme.surfaceContainerHigh
+                clip: true
+
+                required property var modelData
+                readonly property var wallpaper: modelData
+                property bool isCurrent: popout.widget && wallpaper
+                                         && wallpaper.id === popout.widget.currentId
+
+                CachingImage {
+                    anchors.fill: parent
+                    anchors.margins: cell.isCurrent ? 3 : 0
+                    imagePath: popout.widget && cell.wallpaper
+                               ? popout.widget.thumbnailFor(cell.wallpaper.id) : ""
+                    fillMode: Image.PreserveAspectCrop
+                    // Thumbnail grids decode enough as it is.
+                    animate: false
+                }
+
+                // The selection ring is drawn over the image rather than as a
+                // border, so the current wallpaper reads at a glance.
+                Rectangle {
+                    anchors.fill: parent
+                    radius: parent.radius
+                    color: "transparent"
+                    border.width: cell.isCurrent ? 3 : 0
+                    border.color: Theme.primary
+                    visible: cell.isCurrent
+                }
+
+                StateLayer {
+                    cornerRadius: parent.radius
+                    tooltipText: cell.wallpaper
+                                 ? cell.wallpaper.source_type + " · " + cell.wallpaper.width
+                                 + "×" + cell.wallpaper.height
+                                 : null
+                    onClicked: {
+                        if (popout.widget && cell.wallpaper)
+                            popout.widget.setWallpaperById(cell.wallpaper.id)
+                    }
+                }
+            }
+        }
+    }
+
+    // --- Paging -----------------------------------------------------------
+
+    Item {
+        width: parent.width
+        height: visible ? 36 : 0
+        visible: popout.widget && popout.widget.daemonUp && popout.widget.libraryTotal > 0
+
+        StyledText {
+            anchors.left: parent.left
+            anchors.leftMargin: Theme.spacingXS
+            anchors.verticalCenter: parent.verticalCenter
+            font.pixelSize: Theme.fontSizeSmall
+            color: Theme.surfaceVariantText
+            text: {
+                if (!popout.widget || popout.widget.library.length === 0)
+                    return ""
+                const first = popout.widget.libraryOffset + 1
+                const last = popout.widget.libraryOffset + popout.widget.library.length
+                return first + "–" + last + " of " + popout.widget.libraryTotal
+            }
+        }
+
+        Row {
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
+            spacing: Theme.spacingXS
+
+            DankActionButton {
+                iconName: "chevron_left"
+                iconSize: Theme.iconSize - 4
+                enabled: popout.widget && popout.widget.hasPrevPage
+                opacity: enabled ? 1 : 0.35
+                tooltipText: "Previous page"
+                onClicked: {
+                    if (popout.widget)
+                        popout.widget.prevPage()
+                }
+            }
+
+            DankActionButton {
+                iconName: "chevron_right"
+                iconSize: Theme.iconSize - 4
+                enabled: popout.widget && popout.widget.hasNextPage
+                opacity: enabled ? 1 : 0.35
+                tooltipText: "Next page"
+                onClicked: {
+                    if (popout.widget)
+                        popout.widget.nextPage()
+                }
+            }
+        }
+    }
+
+    // --- Transport --------------------------------------------------------
+
+    Item {
+        width: parent.width
+        height: visible ? 40 : 0
+        visible: popout.widget && popout.widget.daemonUp
+
+        Row {
+            anchors.centerIn: parent
+            spacing: Theme.spacingS
+
+            DankActionButton {
+                iconName: "skip_previous"
+                tooltipText: "Previous wallpaper"
+                onClicked: {
+                    if (popout.widget)
+                        popout.widget.prev()
+                }
+            }
+
+            DankActionButton {
+                iconName: popout.widget && popout.widget.paused ? "play_arrow" : "pause"
+                backgroundColor: Theme.primary
+                iconColor: Theme.onPrimary
+                tooltipText: popout.widget && popout.widget.paused
+                             ? "Resume rotation" : "Pause rotation"
+                onClicked: {
+                    if (popout.widget)
+                        popout.widget.togglePause()
+                }
+            }
+
+            DankActionButton {
+                iconName: "skip_next"
+                tooltipText: "Next wallpaper"
+                onClicked: {
+                    if (popout.widget)
+                        popout.widget.next()
+                }
+            }
+        }
+    }
+
+    // --- Mode switcher ----------------------------------------------------
+    //
+    // Every mode is shown; the ones this config cannot run are dimmed with the
+    // reason, rather than hidden or offered as equals. `available_modes` is the
+    // daemon's word on which is which — the missing precondition is always
+    // "nothing declared in config.toml", so the prose is ours to write.
+
+    Flow {
+        width: parent.width
+        spacing: Theme.spacingXS
+        visible: popout.widget && popout.widget.daemonUp
+
+        Repeater {
+            model: popout.widget ? popout.widget.modeOrder : []
+
+            StyledRect {
+                id: chip
+
+                required property var modelData
+                readonly property string modeValue: modelData
+                property bool usable: popout.widget
+                                      && popout.widget.availableModes.indexOf(modeValue) >= 0
+                property bool isCurrent: popout.widget && popout.widget.mode === modeValue
+
+                width: chipRow.implicitWidth + Theme.spacingM * 2
+                height: 30
+                radius: height / 2
+                color: isCurrent ? Theme.primarySelected : Theme.surfaceContainerHigh
+                opacity: usable ? 1 : 0.4
+
+                Row {
+                    id: chipRow
+                    anchors.centerIn: parent
+                    spacing: Theme.spacingXS
+
+                    DankIcon {
+                        anchors.verticalCenter: parent.verticalCenter
+                        name: popout.widget ? popout.widget.modeIcon(chip.modeValue) : "wallpaper"
+                        size: Theme.fontSizeMedium
+                        color: chip.isCurrent ? Theme.primary : Theme.surfaceVariantText
+                    }
+
+                    StyledText {
+                        anchors.verticalCenter: parent.verticalCenter
+                        text: popout.widget ? popout.widget.modeLabel(chip.modeValue) : ""
+                        font.pixelSize: Theme.fontSizeSmall
+                        font.weight: chip.isCurrent ? Font.DemiBold : Font.Normal
+                        color: chip.isCurrent ? Theme.primary : Theme.surfaceText
+                    }
+                }
+
+                StateLayer {
+                    cornerRadius: parent.radius
+                    disabled: !chip.usable
+                    tooltipText: chip.usable
+                                 ? null
+                                 : "Nothing declared in config.toml for this mode"
+                    onClicked: {
+                        if (chip.usable && !chip.isCurrent && popout.widget)
+                            popout.widget.setMode(chip.modeValue)
+                    }
+                }
+            }
+        }
+    }
+
+    // --- Last error -------------------------------------------------------
+    //
+    // Shown on its own once something *is* applied: the banner above only
+    // covers the nothing-applied case, and a failure that happened mid-session
+    // is still worth saying out loud.
+
+    StyledText {
+        width: parent.width
+        wrapMode: Text.WordWrap
+        font.pixelSize: Theme.fontSizeSmall
+        color: Theme.error
+        visible: popout.widget && popout.widget.daemonUp
+                 && popout.widget.lastError !== "" && !popout.widget.nothingApplied
+        text: popout.widget ? "Last apply failed: " + popout.widget.lastError : ""
+    }
+}

--- a/dms-widget/MuralisWidget.qml
+++ b/dms-widget/MuralisWidget.qml
@@ -1,0 +1,436 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.Common
+import qs.Widgets
+import qs.Modules.Plugins
+
+// The muralis Consumer: a DankBar pill plus a popout over the Library.
+//
+// Everything here speaks the daemon socket directly (ADR 0002). Two sockets,
+// because the IPC contract has two shapes:
+//
+//   eventSocket   — one Subscribe, held open forever. It carries the snapshot
+//                   on connect and every change after, which is what keeps the
+//                   matugen palette matching the wallpaper through rotations
+//                   this widget did not initiate.
+//   commandSocket — one-shot requests. The daemon answers a command and hangs
+//                   up, so each one gets a fresh dial; they queue and drain one
+//                   at a time rather than racing each other onto a dead socket.
+PluginComponent {
+    id: root
+
+    // --- Daemon addresses -------------------------------------------------
+
+    // Matches MuralisPaths::socket_path(): /tmp/muralis-$UID.sock. The uid is
+    // the last segment of XDG_RUNTIME_DIR (/run/user/1000), with `id -u` as a
+    // fallback for a session that somehow lacks it — a widget that silently
+    // never connects is the failure mode worth spending ten lines to avoid.
+    property string uid: {
+        const runtime = Quickshell.env("XDG_RUNTIME_DIR") || ""
+        const tail = runtime.split("/").filter(s => s.length > 0).pop() || ""
+        return /^[0-9]+$/.test(tail) ? tail : ""
+    }
+    readonly property string socketPath: uid ? "/tmp/muralis-" + uid + ".sock" : ""
+
+    // Matches MuralisPaths' cache dir; thumbnails are read off disk rather
+    // than through the daemon (README: one file per Wallpaper, <id>_thumb.jpg).
+    readonly property string thumbnailDir: (Quickshell.env("XDG_CACHE_HOME")
+        || (Quickshell.env("HOME") + "/.cache")) + "/muralis/thumbnails"
+
+    function thumbnailFor(id) {
+        return id ? "file://" + thumbnailDir + "/" + id + "_thumb.jpg" : ""
+    }
+
+    Process {
+        command: ["id", "-u"]
+        running: root.uid === ""
+        stdout: SplitParser {
+            onRead: data => {
+                const value = data.trim()
+                if (/^[0-9]+$/.test(value))
+                    root.uid = value
+            }
+        }
+    }
+
+    // --- Daemon state -----------------------------------------------------
+
+    // Fed by the subscription. `currentWallpaper` is the whole Wallpaper row,
+    // so the grid, the pill and SessionData all read one source.
+    property var currentWallpaper: null
+    property string mode: ""
+    property bool paused: false
+
+    // Fed by Status: the facts events do not carry.
+    property var availableModes: []
+    property int wallpaperCount: 0
+    property string lastError: ""
+
+    readonly property bool daemonUp: eventSocket.linkUp
+    readonly property string currentId: currentWallpaper ? currentWallpaper.id : ""
+    // The daemon is up but has nothing on screen — a real state, not an empty
+    // one (see #11). Saying "nothing selected" here reads as a broken widget.
+    readonly property bool nothingApplied: daemonUp && !currentWallpaper
+    readonly property bool libraryEmpty: daemonUp && wallpaperCount === 0
+
+    // --- Library page -----------------------------------------------------
+
+    readonly property int pageSize: 16
+    property var library: []
+    property int libraryTotal: 0
+    property int libraryOffset: 0
+    property bool libraryLoading: false
+    readonly property bool hasPrevPage: libraryOffset > 0
+    readonly property bool hasNextPage: libraryOffset + library.length < libraryTotal
+
+    popoutWidth: 440
+    popoutHeight: 0
+
+    // --- Commands ---------------------------------------------------------
+
+    function setWallpaperById(id) {
+        _request({command: "set_wallpaper", id: id}, () => refreshStatus())
+    }
+
+    function next() {
+        _request({command: "next"}, () => refreshStatus())
+    }
+
+    function prev() {
+        _request({command: "prev"}, () => refreshStatus())
+    }
+
+    function togglePause() {
+        _request({command: paused ? "resume" : "pause"}, () => refreshStatus())
+    }
+
+    function setMode(value) {
+        _request({command: "set_mode", mode: value}, response => {
+            // A refused mode is the daemon telling us the config cannot run it.
+            // Surface it rather than leaving the chip looking stuck.
+            if (response && response.status === "error")
+                root.lastError = response.message || ""
+            refreshStatus()
+        })
+    }
+
+    function refreshStatus() {
+        _request({command: "status"}, response => {
+            if (!response || response.status !== "ok" || !response.data)
+                return
+            const data = response.data
+            root.mode = data.mode || ""
+            root.paused = data.paused === true
+            root.wallpaperCount = data.wallpaper_count || 0
+            root.availableModes = data.available_modes || []
+            root.lastError = data.last_error || ""
+            // Status carries only the id; the row itself arrives on the
+            // subscription. Clearing here keeps the two from disagreeing when
+            // the daemon has nothing applied.
+            if (!data.current_wallpaper)
+                root.currentWallpaper = null
+            // A page load already in flight will answer this; without the
+            // guard, every connect fetches page 0 twice.
+            if (root.libraryTotal !== root.wallpaperCount && !root.libraryLoading)
+                loadPage(0)
+        })
+    }
+
+    function loadPage(offset) {
+        if (!daemonUp)
+            return
+        libraryLoading = true
+        _request({command: "favorites", offset: offset, limit: pageSize}, response => {
+            root.libraryLoading = false
+            if (!response || response.status !== "ok" || !response.data)
+                return
+            root.library = response.data.wallpapers || []
+            root.libraryTotal = response.data.total || 0
+            root.libraryOffset = response.data.offset || 0
+        })
+    }
+
+    function nextPage() {
+        if (hasNextPage)
+            loadPage(libraryOffset + pageSize)
+    }
+
+    function prevPage() {
+        if (hasPrevPage)
+            loadPage(Math.max(0, libraryOffset - pageSize))
+    }
+
+    function refresh() {
+        refreshStatus()
+        loadPage(libraryOffset)
+    }
+
+    // --- Subscription -----------------------------------------------------
+
+    DankSocket {
+        id: eventSocket
+        path: root.socketPath
+        connected: root.socketPath !== ""
+
+        onConnectionStateChanged: {
+            if (linkUp) {
+                // The daemon answers Subscribe with a snapshot, so this is also
+                // how the widget catches up after a redial.
+                send({command: "subscribe"})
+                root.refresh()
+            } else {
+                root.library = []
+                root.libraryTotal = 0
+            }
+        }
+
+        parser: SplitParser {
+            onRead: line => root._onEvent(line)
+        }
+    }
+
+    function _onEvent(line) {
+        const text = (line || "").trim()
+        if (!text)
+            return
+        let event = null
+        try {
+            event = JSON.parse(text)
+        } catch (e) {
+            return
+        }
+        if (!event || !event.event)
+            return
+
+        switch (event.event) {
+        case "wallpaper_changed":
+            _adoptWallpaper(event.wallpaper)
+            break
+        case "mode_changed":
+            root.mode = event.mode || ""
+            break
+        case "pause_changed":
+            root.paused = event.paused === true
+            break
+        }
+        // Unknown event kinds are ignored on purpose: the contract says adding
+        // one is backwards-compatible, so a newer daemon must not break us.
+    }
+
+    function _adoptWallpaper(wallpaper) {
+        if (!wallpaper || !wallpaper.file_path)
+            return
+        root.currentWallpaper = wallpaper
+        root.lastError = ""
+        // The point of the whole exercise: this regenerates DMS's matugen
+        // palette from the image. Guarded, because every redial replays the
+        // snapshot and regenerating a palette we already have is pure cost.
+        if (SessionData.wallpaperPath !== wallpaper.file_path)
+            SessionData.setWallpaper(wallpaper.file_path)
+    }
+
+    // --- One-shot commands ------------------------------------------------
+
+    // The daemon hangs up after answering, so a command dials, sends, reads one
+    // line and drops the socket. Queued rather than concurrent: a fresh dial
+    // per command keeps the reply unambiguous, and commands here are always
+    // user-initiated, never hot.
+    property var _queue: []
+    property var _inFlight: null
+
+    function _request(request, handler) {
+        _queue.push({request: request, handler: handler})
+        _pump()
+    }
+
+    function _pump() {
+        if (_inFlight || _queue.length === 0 || socketPath === "")
+            return
+        _inFlight = _queue.shift()
+        commandTimeout.restart()
+        commandSocket.connected = true
+    }
+
+    function _finish(response) {
+        const entry = _inFlight
+        _inFlight = null
+        commandTimeout.stop()
+        commandSocket.connected = false
+        if (entry && entry.handler)
+            entry.handler(response)
+        Qt.callLater(_pump)
+    }
+
+    DankSocket {
+        id: commandSocket
+        path: root.socketPath
+        connected: false
+        reconnectBaseMs: 100
+
+        onConnectionStateChanged: {
+            if (linkUp && root._inFlight)
+                send(root._inFlight.request)
+        }
+
+        parser: SplitParser {
+            onRead: line => {
+                const text = (line || "").trim()
+                if (!text)
+                    return
+                let response = null
+                try {
+                    response = JSON.parse(text)
+                } catch (e) {
+                    response = null
+                }
+                root._finish(response)
+            }
+        }
+    }
+
+    // A command that never comes back must not wedge the queue behind it.
+    Timer {
+        id: commandTimeout
+        interval: 5000
+        repeat: false
+        onTriggered: {
+            if (root._inFlight)
+                root._finish(null)
+        }
+    }
+
+    // --- Presentation helpers ---------------------------------------------
+
+    readonly property var modeOrder: ["static", "random", "random_startup",
+                                      "sequential", "workspace", "schedule"]
+
+    function modeLabel(value) {
+        switch (value) {
+        case "static": return "Static"
+        case "random": return "Random"
+        case "random_startup": return "At startup"
+        case "sequential": return "Sequential"
+        case "workspace": return "Per workspace"
+        case "schedule": return "Scheduled"
+        }
+        return value || "unknown"
+    }
+
+    function modeIcon(value) {
+        switch (value) {
+        case "static": return "image"
+        case "random": return "shuffle"
+        case "random_startup": return "bolt"
+        case "sequential": return "repeat"
+        case "workspace": return "grid_view"
+        case "schedule": return "schedule"
+        }
+        return "wallpaper"
+    }
+
+    readonly property string pillIcon: {
+        if (!daemonUp)
+            return "cloud_off"
+        if (nothingApplied)
+            return "image_not_supported"
+        return modeIcon(mode)
+    }
+
+    readonly property color pillColor: {
+        if (!daemonUp)
+            return Theme.error
+        if (nothingApplied)
+            return Theme.warning
+        return Theme.surfaceText
+    }
+
+    readonly property string pillText: {
+        if (!daemonUp)
+            return "not running"
+        if (nothingApplied)
+            return "none"
+        return modeLabel(mode)
+    }
+
+    // --- Pills ------------------------------------------------------------
+
+    horizontalBarPill: Component {
+        Row {
+            spacing: Theme.spacingXS
+
+            DankCircularImage {
+                width: root.iconSize
+                height: root.iconSize
+                anchors.verticalCenter: parent.verticalCenter
+                visible: root.currentId !== ""
+                imageSource: root.thumbnailFor(root.currentId)
+                fallbackIcon: "wallpaper"
+            }
+
+            DankIcon {
+                anchors.verticalCenter: parent.verticalCenter
+                visible: root.currentId === ""
+                name: root.pillIcon
+                size: root.iconSize
+                color: root.pillColor
+            }
+
+            DankIcon {
+                anchors.verticalCenter: parent.verticalCenter
+                visible: root.daemonUp && root.paused
+                name: "pause"
+                size: root.iconSize - 4
+                color: Theme.surfaceVariantText
+            }
+
+            StyledText {
+                anchors.verticalCenter: parent.verticalCenter
+                text: root.pillText
+                font.pixelSize: Theme.fontSizeSmall
+                color: root.pillColor
+            }
+        }
+    }
+
+    verticalBarPill: Component {
+        Column {
+            spacing: 2
+
+            DankCircularImage {
+                width: root.iconSize
+                height: root.iconSize
+                anchors.horizontalCenter: parent.horizontalCenter
+                visible: root.currentId !== ""
+                imageSource: root.thumbnailFor(root.currentId)
+                fallbackIcon: "wallpaper"
+            }
+
+            DankIcon {
+                anchors.horizontalCenter: parent.horizontalCenter
+                visible: root.currentId === ""
+                name: root.pillIcon
+                size: root.iconSize
+                color: root.pillColor
+            }
+
+            DankIcon {
+                anchors.horizontalCenter: parent.horizontalCenter
+                visible: root.daemonUp && root.paused
+                name: "pause"
+                size: root.iconSize - 6
+                color: Theme.surfaceVariantText
+            }
+        }
+    }
+
+    // --- Popout -----------------------------------------------------------
+
+    popoutContent: Component {
+        MuralisPopout {
+            widget: root
+        }
+    }
+}

--- a/dms-widget/README.md
+++ b/dms-widget/README.md
@@ -47,48 +47,55 @@ setting `wallpaper` to disabled in `dashTabs` in
 
 `SettingsData.visibleDashTabIds()` reads this; the tab disappears from DankDash.
 
-## CLI contract
+## IPC contract
 
-Everything the widget needs, via `Proc.runCommand`:
+The widget speaks the daemon socket directly through `DankSocket` (`qs.Common`),
+which supplies backoff, jitter, redial and the newline-JSON framing muralis
+already uses. See ADR 0002.
 
-| Command | Used for |
+| `IpcRequest` | Used for |
 | --- | --- |
-| `muralis favorites list` | grid contents: the whole library, JSON array |
-| `muralis status` | current wallpaper, mode, paused, count |
-| `muralis set <id>` | click-to-set |
-| `muralis next` / `muralis prev` | transport |
-| `muralis pause` / `muralis resume` | rotation toggle |
-| `muralis mode <mode>` | static, random, random_startup, sequential, workspace, schedule |
-| `muralis subscribe` | push: wallpaper-changed events, held open ([#9](https://github.com/abjoru/muralis/issues/9)) |
+| `Favorites` | grid contents: the whole library ([#10](https://github.com/abjoru/muralis/issues/10)) |
+| `Status` | current wallpaper, mode, paused, count |
+| `SetWallpaper { id }` | click-to-set |
+| `Next` / `Prev` | transport |
+| `Pause` / `Resume` | rotation toggle |
+| `SetMode { mode }` | static, random, random_startup, sequential, workspace, schedule |
+| `Subscribe` | push: wallpaper-changed events, held open ([#9](https://github.com/abjoru/muralis/issues/9)) |
+
+Both `Favorites` and `Subscribe` are unbuilt — the widget cannot ship before
+them.
 
 Entries carry `id`, `source_type`, `source_id`, `source_url`,
 `width`, `height`, `tags`, `file_path`, `added_at`, `last_used`, `use_count`.
 
-`status` returns `current_wallpaper`, `mode`, `next_change`, `paused`,
+`Status` returns `current_wallpaper`, `mode`, `next_change`, `paused`,
 `running`, `wallpaper_count`.
 
 Thumbnails are read directly from `~/.cache/muralis/thumbnails/<id>_thumb.jpg`,
 one per Wallpaper — not through the CLI.
 
 On every wallpaper change — the widget's own, and rotations arriving over
-`subscribe` — the widget calls `SessionData.setWallpaper(file_path)`. That is not
+`Subscribe` — the widget calls `SessionData.setWallpaper(file_path)`. That is not
 bookkeeping: it regenerates DMS's whole matugen palette from the image, which is
 why push is a v1 blocker rather than a nicety. See ADR 0001.
 
-`subscribe` is a long-lived child process, so the widget owes it a reconnect
-policy: a daemon restart kills the stream, and failing to restart it leaves the
-widget silently deaf.
+Reconnection is not ours to design: `DankSocket` redials with exponential
+backoff and jitter, capped at 15s, allocating a fresh socket per attempt.
 
 ## Failure states
 
-Four states, three of which the widget must render rather than hide.
+Four states, three of which the widget must render rather than hide. Note the
+daemon-down row is a deliberate regression from the CLI design: the grid used to
+survive it by reading the database directly. One honest failure beats a
+half-working widget — see ADR 0002.
 
-| State | `favorites list` | `status` | Widget |
-| --- | --- | --- | --- |
-| muralis not installed | spawn fails | spawn fails | never loads — `StartupCheck.qml` blocks activation with an install hint |
-| daemon down | exit 0, JSON | exit 1, empty stdout | grid usable, transport and mode controls disabled, pill says so |
-| daemon up, nothing applied | exit 0, JSON | exit 0, `current_wallpaper: null` | says so explicitly; grid usable, one click fixes it |
-| empty library | `[]` | exit 0, `wallpaper_count: 0` | empty-state pointing at `muralis search` |
+| State | Socket | Widget |
+| --- | --- | --- |
+| muralis not installed | — | never loads — `StartupCheck.qml` blocks activation with an install hint |
+| daemon down | connect fails, DankSocket retrying | one honest state: "muralis is not running". No grid — it lives behind the same socket |
+| daemon up, nothing applied | connects, `current_wallpaper: null` | says so explicitly; grid usable, one click fixes it |
+| empty library | connects, `wallpaper_count: 0` | empty-state pointing at `muralis search` |
 
 Note `dependencies` in the manifest gates nothing — the schema calls it registry
 metadata, and neither it nor its deprecated alias `requires` is enforced anywhere
@@ -108,7 +115,7 @@ lands; it will not become impossible, since any backend hiccup reproduces it.
 First cut is parity with the old WallpaperTab patch: library grid with
 thumbnails and paging, click-to-set, next/prev, pause/resume, mode switch,
 SessionData sync, and selection following `current_wallpaper` — plus consuming
-`muralis subscribe`, so the pill and the palette stay correct through timed
+`Subscribe`, so the pill and the palette stay correct through timed
 rotations the widget did not initiate.
 
 Search, tag filtering, per-monitor wallpapers and source browsing are

--- a/dms-widget/README.md
+++ b/dms-widget/README.md
@@ -55,7 +55,7 @@ already uses. See ADR 0002.
 
 | `IpcRequest` | Used for |
 | --- | --- |
-| `Favorites` | grid contents: the whole library ([#10](https://github.com/abjoru/muralis/issues/10)) |
+| `Favorites { offset, limit }` | grid contents: a window onto the library, or the whole thing when both are omitted |
 | `Status` | current wallpaper, mode, paused, count |
 | `SetWallpaper { id }` | click-to-set |
 | `Next` / `Prev` | transport |
@@ -63,8 +63,7 @@ already uses. See ADR 0002.
 | `SetMode { mode }` | static, random, random_startup, sequential, workspace, schedule — offered per `available_modes` ([#14](https://github.com/abjoru/muralis/issues/14)) |
 | `Subscribe` | push: wallpaper-changed events, held open ([#9](https://github.com/abjoru/muralis/issues/9)) |
 
-Both `Favorites` and `Subscribe` are unbuilt — the widget cannot ship before
-them.
+`Subscribe` is unbuilt — the widget cannot ship before it.
 
 ### Mode switching
 
@@ -79,8 +78,12 @@ so the widget's filtering is a courtesy, not the safety net.
 A mode chosen here persists to `config.toml` ([#12](https://github.com/abjoru/muralis/issues/12));
 until that lands it silently reverts on daemon restart.
 
-Entries carry `id`, `source_type`, `source_id`, `source_url`,
-`width`, `height`, `tags`, `file_path`, `added_at`, `last_used`, `use_count`.
+`Favorites` answers with `wallpapers`, `total` and the `offset` it served, so the
+grid can size its scrollbar without holding the whole library. Entries carry
+`id`, `source_type`, `source_id`, `source_url`, `width`, `height`, `tags`,
+`file_path`, `added_at`, `last_used`, `use_count` — ~445 B each, so the 16-item
+page the grid draws is ~7 KiB where a 1000-wallpaper library would be ~435 KiB in
+one socket line.
 
 `Status` returns `current_wallpaper`, `mode`, `next_change`, `paused`,
 `running`, `wallpaper_count`, `last_error`.

--- a/dms-widget/README.md
+++ b/dms-widget/README.md
@@ -63,7 +63,8 @@ already uses. See ADR 0002.
 | `SetMode { mode }` | static, random, random_startup, sequential, workspace, schedule — offered per `available_modes` ([#14](https://github.com/abjoru/muralis/issues/14)) |
 | `Subscribe` | push: wallpaper-changed events, held open ([#9](https://github.com/abjoru/muralis/issues/9)) |
 
-`Subscribe` is unbuilt — the widget cannot ship before it.
+Every one of these is built. `Subscribe` ([#9](https://github.com/abjoru/muralis/issues/9))
+was the last, and is what the widget holds open for the life of the session.
 
 ### Mode switching
 
@@ -78,8 +79,9 @@ shipping prose for it. The daemon refuses an
 unusable mode regardless ([#13](https://github.com/abjoru/muralis/issues/13)),
 so the widget's filtering is a courtesy, not the safety net.
 
-A mode chosen here persists to `config.toml` ([#12](https://github.com/abjoru/muralis/issues/12));
-until that lands it silently reverts on daemon restart.
+A mode chosen here persists to `config.toml`
+([#12](https://github.com/abjoru/muralis/issues/12)), so it survives a daemon
+restart.
 
 `Favorites` answers with `wallpapers`, `total` and the `offset` it served, so the
 grid can size its scrollbar without holding the whole library. Entries carry
@@ -109,6 +111,33 @@ why push is a v1 blocker rather than a nicety. See ADR 0001.
 
 Reconnection is not ours to design: `DankSocket` redials with exponential
 backoff and jitter, capped at 15s, allocating a fresh socket per attempt.
+
+### Two sockets
+
+The contract has two shapes, so the widget opens two connections:
+
+- **`eventSocket`** holds one `Subscribe` open for the life of the session. It
+  carries a snapshot on connect — so a redial resynchronises without a separate
+  request — and every change after. This is the one that keeps the matugen
+  palette matching the wallpaper through rotations the widget did not initiate,
+  which is the whole reason the widget exists rather than polling.
+- **`commandSocket`** carries one-shot requests. The daemon answers a command
+  and hangs up, so each gets a fresh dial; they queue and drain one at a time
+  rather than racing onto a socket that is already closing. Commands here are
+  always user-initiated, so the extra dial costs nothing anyone can perceive.
+
+`SessionData.setWallpaper()` is called only when the path actually differs from
+what DMS already has. Every redial replays the snapshot, and regenerating a
+palette we already have is pure cost.
+
+## Files
+
+| File | Role |
+| --- | --- |
+| `plugin.json` | DMS manifest. `component` and `startupCheck` are the only fields that gate anything |
+| `MuralisWidget.qml` | The `PluginComponent`: both sockets, all daemon state, both bar pills |
+| `MuralisPopout.qml` | The popout view — grid, paging, transport, mode chips. Owns no socket; every value it draws is a property of the widget |
+| `StartupCheck.qml` | Blocks activation when the `muralis` binary is absent |
 
 ## Failure states
 

--- a/dms-widget/README.md
+++ b/dms-widget/README.md
@@ -70,8 +70,11 @@ already uses. See ADR 0002.
 `workspace` and `schedule` only function when `config.toml` declares workspaces
 or schedules, and the widget is not a config editor. It offers the modes the
 daemon reports as usable in `available_modes` ([#14](https://github.com/abjoru/muralis/issues/14))
-and greys out the rest with the reason, rather than presenting six equal choices
-of which two may silently stop the wallpaper changing. The daemon refuses an
+and greys out the rest, rather than presenting six equal choices of which two
+may silently stop the wallpaper changing. `available_modes` carries the set, not
+the reason — the missing precondition is always "nothing declared in
+`config.toml`", so the widget writes that itself rather than the daemon
+shipping prose for it. The daemon refuses an
 unusable mode regardless ([#13](https://github.com/abjoru/muralis/issues/13)),
 so the widget's filtering is a courtesy, not the safety net.
 
@@ -86,7 +89,10 @@ page the grid draws is ~7 KiB where a 1000-wallpaper library would be ~435 KiB i
 one socket line.
 
 `Status` returns `current_wallpaper`, `mode`, `next_change`, `paused`,
-`running`, `wallpaper_count`, `last_error`.
+`running`, `wallpaper_count`, `available_modes`, `last_error`.
+
+`available_modes` is the modes this config can actually run, in
+`DisplayMode::ALL` order — the switcher offers these and greys out the rest.
 
 `last_error` is why the daemon's last apply failed, `null` once one succeeds
 ([#11](https://github.com/abjoru/muralis/issues/11)). It is what separates

--- a/dms-widget/README.md
+++ b/dms-widget/README.md
@@ -60,11 +60,24 @@ already uses. See ADR 0002.
 | `SetWallpaper { id }` | click-to-set |
 | `Next` / `Prev` | transport |
 | `Pause` / `Resume` | rotation toggle |
-| `SetMode { mode }` | static, random, random_startup, sequential, workspace, schedule |
+| `SetMode { mode }` | static, random, random_startup, sequential, workspace, schedule — offered per `available_modes` ([#14](https://github.com/abjoru/muralis/issues/14)) |
 | `Subscribe` | push: wallpaper-changed events, held open ([#9](https://github.com/abjoru/muralis/issues/9)) |
 
 Both `Favorites` and `Subscribe` are unbuilt — the widget cannot ship before
 them.
+
+### Mode switching
+
+`workspace` and `schedule` only function when `config.toml` declares workspaces
+or schedules, and the widget is not a config editor. It offers the modes the
+daemon reports as usable in `available_modes` ([#14](https://github.com/abjoru/muralis/issues/14))
+and greys out the rest with the reason, rather than presenting six equal choices
+of which two may silently stop the wallpaper changing. The daemon refuses an
+unusable mode regardless ([#13](https://github.com/abjoru/muralis/issues/13)),
+so the widget's filtering is a courtesy, not the safety net.
+
+A mode chosen here persists to `config.toml` ([#12](https://github.com/abjoru/muralis/issues/12));
+until that lands it silently reverts on daemon restart.
 
 Entries carry `id`, `source_type`, `source_id`, `source_url`,
 `width`, `height`, `tags`, `file_path`, `added_at`, `last_used`, `use_count`.

--- a/dms-widget/README.md
+++ b/dms-widget/README.md
@@ -2,7 +2,7 @@
 
 A [DankMaterialShell](https://github.com/AvengeMedia/DankMaterialShell) widget:
 a DankBar pill showing the current wallpaper, and a popout with the muralis
-favorites grid plus transport and mode controls.
+library grid plus transport and mode controls.
 
 DMS calls this a *plugin* — hence `plugin.json`, and installation under
 `~/.config/DankMaterialShell/plugins/`. This repo does not: `CONTEXT.md`
@@ -31,7 +31,7 @@ ln -s "$PWD/dms-widget" ~/.config/DankMaterialShell/plugins/muralis
 
 Enable it in DMS Settings → Plugins, then add the widget to a DankBar section.
 
-Hide DMS's built-in wallpaper tab (it browses a directory, not favorites) by
+Hide DMS's built-in wallpaper tab (it browses a directory, not the library) by
 setting `wallpaper` to disabled in `dashTabs` in
 `~/.config/DankMaterialShell/settings.json`:
 
@@ -53,7 +53,7 @@ Everything the widget needs, via `Proc.runCommand`:
 
 | Command | Used for |
 | --- | --- |
-| `muralis favorites list` | grid contents (JSON array) |
+| `muralis favorites list` | grid contents: the whole library, JSON array |
 | `muralis status` | current wallpaper, mode, paused, count |
 | `muralis set <id>` | click-to-set |
 | `muralis next` / `muralis prev` | transport |
@@ -61,14 +61,14 @@ Everything the widget needs, via `Proc.runCommand`:
 | `muralis mode <mode>` | static, random, random_startup, sequential, workspace, schedule |
 | `muralis subscribe` | push: wallpaper-changed events, held open ([#9](https://github.com/abjoru/muralis/issues/9)) |
 
-`favorites list` entries carry `id`, `source_type`, `source_id`, `source_url`,
+Entries carry `id`, `source_type`, `source_id`, `source_url`,
 `width`, `height`, `tags`, `file_path`, `added_at`, `last_used`, `use_count`.
 
 `status` returns `current_wallpaper`, `mode`, `next_change`, `paused`,
 `running`, `wallpaper_count`.
 
 Thumbnails are read directly from `~/.cache/muralis/thumbnails/<id>_thumb.jpg`,
-one per favorite — not through the CLI.
+one per Wallpaper — not through the CLI.
 
 On every wallpaper change — the widget's own, and rotations arriving over
 `subscribe` — the widget calls `SessionData.setWallpaper(file_path)`. That is not
@@ -81,11 +81,13 @@ widget silently deaf.
 
 ## Scope
 
-First cut is parity with the old WallpaperTab patch: favorites grid with
+First cut is parity with the old WallpaperTab patch: library grid with
 thumbnails and paging, click-to-set, next/prev, pause/resume, mode switch,
 SessionData sync, and selection following `current_wallpaper` — plus consuming
 `muralis subscribe`, so the pill and the palette stay correct through timed
 rotations the widget did not initiate.
 
-Search, tag filtering, per-monitor wallpapers, favorite/unfavorite and source
-browsing are deliberately out of the first cut.
+Search, tag filtering, per-monitor wallpapers and source browsing are
+deliberately out of the first cut. Search is affordable to omit only while the
+library stays small — the grid pages 16 at a time over the *whole* library, since
+muralis has no curated subset within it (see **Library** in `CONTEXT.md`).

--- a/dms-widget/README.md
+++ b/dms-widget/README.md
@@ -83,7 +83,12 @@ Entries carry `id`, `source_type`, `source_id`, `source_url`,
 `width`, `height`, `tags`, `file_path`, `added_at`, `last_used`, `use_count`.
 
 `Status` returns `current_wallpaper`, `mode`, `next_change`, `paused`,
-`running`, `wallpaper_count`.
+`running`, `wallpaper_count`, `last_error`.
+
+`last_error` is why the daemon's last apply failed, `null` once one succeeds
+([#11](https://github.com/abjoru/muralis/issues/11)). It is what separates
+"nothing applied yet" from "the backend refused" — the widget shows the reason
+rather than inventing one.
 
 Thumbnails are read directly from `~/.cache/muralis/thumbnails/<id>_thumb.jpg`,
 one per Wallpaper — not through the CLI.
@@ -107,7 +112,7 @@ half-working widget — see ADR 0002.
 | --- | --- | --- |
 | muralis not installed | — | never loads — `StartupCheck.qml` blocks activation with an install hint |
 | daemon down | connect fails, DankSocket retrying | one honest state: "muralis is not running". No grid — it lives behind the same socket |
-| daemon up, nothing applied | connects, `current_wallpaper: null` | says so explicitly; grid usable, one click fixes it |
+| daemon up, nothing applied | connects, `current_wallpaper: null`, maybe `last_error` | says so explicitly, with `last_error` as the reason when there is one; grid usable, one click fixes it |
 | empty library | connects, `wallpaper_count: 0` | empty-state pointing at `muralis search` |
 
 Note `dependencies` in the manifest gates nothing — the schema calls it registry
@@ -115,13 +120,14 @@ metadata, and neither it nor its deprecated alias `requires` is enforced anywher
 in `PluginService.qml` or the installer. `startupCheck` is the only real gate.
 
 The third row is a real state, not a hypothetical: muralis applies its
-`random_startup` wallpaper exactly once and drops backend failures silently, so
-losing a startup race leaves a wallpaper on screen that muralis does not know
-about ([#11](https://github.com/abjoru/muralis/issues/11)). Reporting "nothing
+`random_startup` wallpaper exactly once, so losing the startup race with the
+backend daemon left a wallpaper on screen that muralis did not know about
+([#11](https://github.com/abjoru/muralis/issues/11)). Reporting "nothing
 selected" there would read as the widget being broken, when the truth is that the
 daemon applied nothing this session. The widget says which, because it is the
-only component positioned to surface it. The state should become rare once #11
-lands; it will not become impossible, since any backend hiccup reproduces it.
+only component positioned to surface it. #11 made the state rare — the daemon now
+waits for the backend before its startup apply — and no longer silent: a failure
+that does happen arrives as `last_error`.
 
 ## Scope
 

--- a/dms-widget/README.md
+++ b/dms-widget/README.md
@@ -79,6 +79,30 @@ why push is a v1 blocker rather than a nicety. See ADR 0001.
 policy: a daemon restart kills the stream, and failing to restart it leaves the
 widget silently deaf.
 
+## Failure states
+
+Four states, three of which the widget must render rather than hide.
+
+| State | `favorites list` | `status` | Widget |
+| --- | --- | --- | --- |
+| muralis not installed | spawn fails | spawn fails | never loads — `StartupCheck.qml` blocks activation with an install hint |
+| daemon down | exit 0, JSON | exit 1, empty stdout | grid usable, transport and mode controls disabled, pill says so |
+| daemon up, nothing applied | exit 0, JSON | exit 0, `current_wallpaper: null` | says so explicitly; grid usable, one click fixes it |
+| empty library | `[]` | exit 0, `wallpaper_count: 0` | empty-state pointing at `muralis search` |
+
+Note `dependencies` in the manifest gates nothing — the schema calls it registry
+metadata, and neither it nor its deprecated alias `requires` is enforced anywhere
+in `PluginService.qml` or the installer. `startupCheck` is the only real gate.
+
+The third row is a real state, not a hypothetical: muralis applies its
+`random_startup` wallpaper exactly once and drops backend failures silently, so
+losing a startup race leaves a wallpaper on screen that muralis does not know
+about ([#11](https://github.com/abjoru/muralis/issues/11)). Reporting "nothing
+selected" there would read as the widget being broken, when the truth is that the
+daemon applied nothing this session. The widget says which, because it is the
+only component positioned to surface it. The state should become rare once #11
+lands; it will not become impossible, since any backend hiccup reproduces it.
+
 ## Scope
 
 First cut is parity with the old WallpaperTab patch: library grid with

--- a/dms-widget/README.md
+++ b/dms-widget/README.md
@@ -59,6 +59,7 @@ Everything the widget needs, via `Proc.runCommand`:
 | `muralis next` / `muralis prev` | transport |
 | `muralis pause` / `muralis resume` | rotation toggle |
 | `muralis mode <mode>` | static, random, random_startup, sequential, workspace, schedule |
+| `muralis subscribe` | push: wallpaper-changed events, held open ([#9](https://github.com/abjoru/muralis/issues/9)) |
 
 `favorites list` entries carry `id`, `source_type`, `source_id`, `source_url`,
 `width`, `height`, `tags`, `file_path`, `added_at`, `last_used`, `use_count`.
@@ -69,14 +70,22 @@ Everything the widget needs, via `Proc.runCommand`:
 Thumbnails are read directly from `~/.cache/muralis/thumbnails/<id>_thumb.jpg`,
 one per favorite — not through the CLI.
 
-On set, the widget also calls `SessionData.setWallpaper(file_path)` so the rest
-of DMS (lock screen, blurred backgrounds, matugen theming) sees the change.
+On every wallpaper change — the widget's own, and rotations arriving over
+`subscribe` — the widget calls `SessionData.setWallpaper(file_path)`. That is not
+bookkeeping: it regenerates DMS's whole matugen palette from the image, which is
+why push is a v1 blocker rather than a nicety. See ADR 0001.
+
+`subscribe` is a long-lived child process, so the widget owes it a reconnect
+policy: a daemon restart kills the stream, and failing to restart it leaves the
+widget silently deaf.
 
 ## Scope
 
 First cut is parity with the old WallpaperTab patch: favorites grid with
 thumbnails and paging, click-to-set, next/prev, pause/resume, mode switch,
-SessionData sync, and selection following `current_wallpaper`.
+SessionData sync, and selection following `current_wallpaper` — plus consuming
+`muralis subscribe`, so the pill and the palette stay correct through timed
+rotations the widget did not initiate.
 
 Search, tag filtering, per-monitor wallpapers, favorite/unfavorite and source
 browsing are deliberately out of the first cut.

--- a/dms-widget/README.md
+++ b/dms-widget/README.md
@@ -1,0 +1,82 @@
+# Muralis DMS widget
+
+A [DankMaterialShell](https://github.com/AvengeMedia/DankMaterialShell) widget:
+a DankBar pill showing the current wallpaper, and a popout with the muralis
+favorites grid plus transport and mode controls.
+
+DMS calls this a *plugin* — hence `plugin.json`, and installation under
+`~/.config/DankMaterialShell/plugins/`. This repo does not: `CONTEXT.md`
+reserves "plugin" for a Rust source crate implementing `create_sources`. The
+directory is named for DMS's own narrower word, `widget`, so nothing in the repo
+root reads as a wallpaper source that isn't one.
+
+Replaces the old approach of overwriting DMS's `DankDash/WallpaperTab.qml` in
+`/usr/share`, which DMS 1.6 ended by embedding the whole UI in the `dms` binary.
+
+## Why it lives in the muralis repo
+
+The widget's entire contract is the muralis CLI's JSON output. Versioning them
+apart is how that contract silently drifts. The DMS plugin registry supports
+monorepo subdirectories natively — a registry entry carries `repo` plus an
+optional `path`, and the installer clones into `plugins/.repos/<name>` then
+installs `<repo>/<path>`. So living here costs nothing in distribution.
+
+## Install
+
+Until it is in a registry:
+
+```bash
+ln -s "$PWD/dms-widget" ~/.config/DankMaterialShell/plugins/muralis
+```
+
+Enable it in DMS Settings → Plugins, then add the widget to a DankBar section.
+
+Hide DMS's built-in wallpaper tab (it browses a directory, not favorites) by
+setting `wallpaper` to disabled in `dashTabs` in
+`~/.config/DankMaterialShell/settings.json`:
+
+```json
+"dashTabs": [
+    { "id": "overview",  "enabled": true  },
+    { "id": "media",     "enabled": true  },
+    { "id": "wallpaper", "enabled": false },
+    { "id": "weather",   "enabled": true  },
+    { "id": "settings",  "enabled": true  }
+]
+```
+
+`SettingsData.visibleDashTabIds()` reads this; the tab disappears from DankDash.
+
+## CLI contract
+
+Everything the widget needs, via `Proc.runCommand`:
+
+| Command | Used for |
+| --- | --- |
+| `muralis favorites list` | grid contents (JSON array) |
+| `muralis status` | current wallpaper, mode, paused, count |
+| `muralis set <id>` | click-to-set |
+| `muralis next` / `muralis prev` | transport |
+| `muralis pause` / `muralis resume` | rotation toggle |
+| `muralis mode <mode>` | static, random, random_startup, sequential, workspace, schedule |
+
+`favorites list` entries carry `id`, `source_type`, `source_id`, `source_url`,
+`width`, `height`, `tags`, `file_path`, `added_at`, `last_used`, `use_count`.
+
+`status` returns `current_wallpaper`, `mode`, `next_change`, `paused`,
+`running`, `wallpaper_count`.
+
+Thumbnails are read directly from `~/.cache/muralis/thumbnails/<id>_thumb.jpg`,
+one per favorite — not through the CLI.
+
+On set, the widget also calls `SessionData.setWallpaper(file_path)` so the rest
+of DMS (lock screen, blurred backgrounds, matugen theming) sees the change.
+
+## Scope
+
+First cut is parity with the old WallpaperTab patch: favorites grid with
+thumbnails and paging, click-to-set, next/prev, pause/resume, mode switch,
+SessionData sync, and selection following `current_wallpaper`.
+
+Search, tag filtering, per-monitor wallpapers, favorite/unfavorite and source
+browsing are deliberately out of the first cut.

--- a/dms-widget/StartupCheck.qml
+++ b/dms-widget/StartupCheck.qml
@@ -1,0 +1,41 @@
+import QtQuick
+import Quickshell.Io
+
+// The only real gate on this widget loading.
+//
+// `dependencies` in plugin.json gates nothing — the schema calls it registry
+// metadata and nothing in PluginService enforces it — so the binary check
+// happens here. DMS calls `check(done)` and treats a null result as pass; a
+// string or {title, details} fails activation and raises a toast.
+QtObject {
+    id: root
+
+    property var _done: null
+
+    property Process probe: Process {
+        command: ["sh", "-c", "command -v muralis >/dev/null 2>&1"]
+        running: false
+
+        onExited: exitCode => {
+            const done = root._done
+            root._done = null
+            if (!done)
+                return
+            if (exitCode === 0) {
+                done(null)
+                return
+            }
+            done({
+                "title": "muralis is not installed",
+                "details": "This widget drives the muralis daemon over its socket "
+                    + "at /tmp/muralis-$UID.sock. Install muralis, start "
+                    + "muralis-daemon, then enable the widget again."
+            })
+        }
+    }
+
+    function check(done) {
+        root._done = done
+        probe.running = true
+    }
+}

--- a/dms-widget/plugin.json
+++ b/dms-widget/plugin.json
@@ -2,13 +2,19 @@
     "$schema": "https://danklinux.com/schemas/plugin.json",
     "id": "muralis",
     "name": "Muralis",
-    "description": "Browse muralis favorites and drive wallpaper rotation from the DankBar",
+    "description": "Browse the muralis library and drive wallpaper rotation from the DankBar",
     "version": "0.1.0",
     "author": "abjoru",
     "type": "widget",
-    "capabilities": ["wallpaper", "dankbar-widget"],
+    "capabilities": [
+        "wallpaper",
+        "dankbar-widget"
+    ],
     "component": "./MuralisWidget.qml",
     "icon": "wallpaper",
-    "requires_dms": ">=1.6.0",
-    "requires": ["muralis"]
+    "dependencies": [
+        "muralis"
+    ],
+    "startupCheck": "./StartupCheck.qml",
+    "requires_dms": ">=1.6.0"
 }

--- a/dms-widget/plugin.json
+++ b/dms-widget/plugin.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://danklinux.com/schemas/plugin.json",
+    "id": "muralis",
+    "name": "Muralis",
+    "description": "Browse muralis favorites and drive wallpaper rotation from the DankBar",
+    "version": "0.1.0",
+    "author": "abjoru",
+    "type": "widget",
+    "capabilities": ["wallpaper", "dankbar-widget"],
+    "component": "./MuralisWidget.qml",
+    "icon": "wallpaper",
+    "requires_dms": ">=1.6.0",
+    "requires": ["muralis"]
+}

--- a/docs/adr/0001-cli-transport-for-consumers.md
+++ b/docs/adr/0001-cli-transport-for-consumers.md
@@ -1,0 +1,46 @@
+---
+status: accepted
+---
+
+# Consumers drive muralis through the CLI, not the daemon socket
+
+A **Consumer** (first: the **DMS Widget**) spawns `muralis` as a subprocess and
+parses its JSON, rather than connecting to the daemon's Unix socket at
+`/tmp/muralis-$UID.sock`. The socket exists and speaks newline-delimited JSON,
+so this looks like the long way round. It isn't: the socket cannot serve the
+favorites grid at all, and the CLI is the seam we already promise to keep
+stable.
+
+## Considered options
+
+**Speak the socket directly from the Consumer.** Rejected for v1. `IpcRequest`
+has no favorites variant — `favorites list` opens SQLite directly in the CLI
+process — so a socket-only Consumer cannot draw its grid. It would speak two
+protocols and still spawn a process for the most expensive call.
+
+**Extend the IPC protocol first, then speak the socket.** Rejected as v1
+sequencing, not on merit; it is the intended successor. See
+[#9](https://github.com/abjoru/muralis/issues/9). Doing it first front-loads a
+daemon change and JSON framing work before we know the widget's shape is right.
+
+**Spawn the CLI for everything.** Chosen. One transport, one failure mode in the
+Consumer, no protocol framing re-implemented in a foreign codebase. It also
+matches how DankMaterialShell's own shell behaves: its QML instantiates no raw
+socket anywhere, shelling out to its Go binary even for niri and sway, and using
+socket paths only as presence probes.
+
+## Consequences
+
+The daemon cannot push. `send_request` writes one line, shuts down the writer,
+reads one line, returns — there is no subscription. A Consumer therefore cannot
+learn that a timed rotation changed the wallpaper, and the DMS Widget's bar pill
+is knowingly stale between rotations in v1. Accepted deliberately: the
+alternative is a timer spawning a process on an idle machine forever.
+
+The **CLI contract** spans two backing stores — the DB for favorites, the socket
+for status and mutations — so a Consumer sees a working grid and a failing
+status when the daemon is down. Consumers must render that split, not treat
+daemon-down as all-or-nothing.
+
+Swapping transport later does not disturb Consumer UI, provided each Consumer
+keeps command invocation behind the function that loads its model.

--- a/docs/adr/0001-cli-transport-for-consumers.md
+++ b/docs/adr/0001-cli-transport-for-consumers.md
@@ -18,10 +18,10 @@ has no favorites variant — `favorites list` opens SQLite directly in the CLI
 process — so a socket-only Consumer cannot draw its grid. It would speak two
 protocols and still spawn a process for the most expensive call.
 
-**Extend the IPC protocol first, then speak the socket.** Rejected as v1
-sequencing, not on merit; it is the intended successor. See
-[#9](https://github.com/abjoru/muralis/issues/9). Doing it first front-loads a
-daemon change and JSON framing work before we know the widget's shape is right.
+**Extend the IPC protocol first, then speak the socket.** Rejected — but see
+the amendment below, which adopts the push half of it via a streaming CLI
+command rather than socket access. Consumers speaking the socket directly stays
+rejected.
 
 **Spawn the CLI for everything.** Chosen. One transport, one failure mode in the
 Consumer, no protocol framing re-implemented in a foreign codebase. It also
@@ -31,12 +31,6 @@ socket paths only as presence probes.
 
 ## Consequences
 
-The daemon cannot push. `send_request` writes one line, shuts down the writer,
-reads one line, returns — there is no subscription. A Consumer therefore cannot
-learn that a timed rotation changed the wallpaper, and the DMS Widget's bar pill
-is knowingly stale between rotations in v1. Accepted deliberately: the
-alternative is a timer spawning a process on an idle machine forever.
-
 The **CLI contract** spans two backing stores — the DB for favorites, the socket
 for status and mutations — so a Consumer sees a working grid and a failing
 status when the daemon is down. Consumers must render that split, not treat
@@ -44,3 +38,28 @@ daemon-down as all-or-nothing.
 
 Swapping transport later does not disturb Consumer UI, provided each Consumer
 keeps command invocation behind the function that loads its model.
+
+## Amendment: streaming commands are part of this decision
+
+Originally this ADR accepted that Consumers cannot be told about wallpaper
+changes they did not initiate, since the socket is one-shot. That was priced as
+a stale label in the DMS Widget's bar pill and accepted for v1.
+
+It was mispriced. A Consumer syncing a wallpaper change into DankMaterialShell
+calls `SessionData.setWallpaper()`, which regenerates the shell's entire matugen
+palette from the image. "No push" therefore means the desktop's accent colours
+silently stop matching the wallpaper after every timed rotation — a visible
+defect, not a cosmetic limitation. See [#9](https://github.com/abjoru/muralis/issues/9).
+
+The fix does not overturn this decision, it extends it: push arrives as a
+streaming `muralis subscribe` command writing newline-delimited JSON to stdout,
+not as socket access from the Consumer. Consumers still drive muralis through
+the CLI. A long-lived child process with a line parser on stdout is how
+DankMaterialShell consumes every other stream it has, so this stays inside both
+codebases' existing patterns.
+
+The corollary is that **the CLI contract includes streaming commands, not only
+request/response ones** — and that a Consumer holding a long-lived child process
+owes it a reconnect policy, since a daemon restart kills the stream and a
+Consumer that fails to restart it goes deaf exactly like the polling design this
+replaces.

--- a/docs/adr/0001-cli-transport-for-consumers.md
+++ b/docs/adr/0001-cli-transport-for-consumers.md
@@ -1,8 +1,14 @@
 ---
-status: accepted
+status: superseded by ADR-0002
 ---
 
 # Consumers drive muralis through the CLI, not the daemon socket
+
+> **Superseded by [ADR 0002](0002-consumers-speak-the-daemon-socket.md).** The
+> claim below that DankMaterialShell's QML never speaks raw sockets is false — it
+> does, via its `DankSocket` wrapper, which also supplies the reconnect policy
+> this ADR's amendment left as an open problem. Kept as a record of the reasoning
+> and of what the correction was.
 
 A **Consumer** (first: the **DMS Widget**) spawns `muralis` as a subprocess and
 parses its JSON, rather than connecting to the daemon's Unix socket at

--- a/docs/adr/0002-consumers-speak-the-daemon-socket.md
+++ b/docs/adr/0002-consumers-speak-the-daemon-socket.md
@@ -1,0 +1,59 @@
+---
+status: accepted
+supersedes: ADR-0001
+---
+
+# Consumers speak the daemon socket via DankSocket
+
+A **Consumer** connects to the daemon's Unix socket at `/tmp/muralis-$UID.sock`
+and speaks the **IPC contract** directly, rather than spawning `muralis` per
+action. This reverses [ADR 0001](0001-cli-transport-for-consumers.md), which was
+decided on a false premise.
+
+## Why 0001 was wrong
+
+It rested on two claims. One was a matter of fact and was simply incorrect:
+DankMaterialShell's QML does speak raw sockets, through its own `DankSocket`
+wrapper (`dank-qml-common/DankCommon/Common/DankSocket.qml`), re-exported by DMS
+in `quickshell/Common/` and reachable by plugins via the supported `qs.Common`
+import. `MangoService` alone runs three of them.
+
+DankSocket is not a thin shim. It carries exponential backoff with jitter
+(400 ms base, 15 s cap), allocates a fresh `Socket` per attempt to work around
+Quickshell's inability to redial a failed one, and its `send()` JSON-encodes and
+newline-terminates every message — which is already muralis's exact wire format.
+With `parser: SplitParser` on the read side, there is no framing left for a
+Consumer to write.
+
+So 0001's "no protocol framing re-implemented in a foreign codebase" argued for
+the CLI on work that does not exist, and its stale-pill consequence would have
+had us hand-roll a reconnect loop markedly worse than the one already shipped.
+
+## What was actually load-bearing
+
+0001's other claim was true and is what kept it alive: `IpcRequest` had no
+favorites variant, so a socket-only Consumer could not draw its grid. That is a
+missing protocol feature, not a reason to choose a transport — so we add it
+(#10) rather than route around it.
+
+## Consequences
+
+Consumers need both halves of the protocol work before they can ship: the
+`Subscribe` event stream (#9) and the `Favorites` request (#10). Neither is
+large; the `set_current()` chokepoint in #9 was owed regardless.
+
+The **CLI contract** does not go away. It remains the seam for scripts, keybinds
+and humans, and keeps its own promise — notably that `favorites list` answers
+from the database even with the daemon down. Consumers simply are not its
+audience.
+
+A Consumer now has **one** failure mode rather than two. Under 0001 the grid
+worked while status failed, and every Consumer had to render that split; now
+"the daemon is not running" is a single honest state. The cost is that the grid
+no longer works daemon-down — deliberate, since a half-working widget is worse
+than one that says what is wrong.
+
+Reconnection is no longer ours to design. Backoff, jitter and redial belong to
+DankSocket, and a Consumer on another shell without an equivalent inherits that
+work — the first non-DMS Consumer should re-examine this decision rather than
+assume it.

--- a/docs/adr/0003-subscriptions-open-with-a-snapshot.md
+++ b/docs/adr/0003-subscriptions-open-with-a-snapshot.md
@@ -1,0 +1,76 @@
+---
+status: accepted
+---
+
+# A subscription carries whole rows and opens with a snapshot
+
+The `Subscribe` request on the daemon socket is held open and answered with
+newline-delimited **Daemon events**, starting with a **Snapshot** of current
+state. Each event is tagged (`{"event": …}`) and self-sufficient —
+`wallpaper_changed` carries the whole `Wallpaper` row.
+
+This settles the three questions [#9](../../issues/9) was labelled
+`ready-for-human` for: framing, payload, and what a subscriber sees on connect.
+
+## Framing: one handler, one accept path
+
+`handle_connection` reads its one request line as before and branches on
+`Subscribe` instead of dispatching. Everything else keeps the write / hang-up
+shape that scripts and keybinds depend on, and there is no second listener to
+keep in step with the first — the socket, the parse and the error reply are
+written once.
+
+The subscriber's `broadcast::Receiver` is taken *before* the request line is
+read. An event fired between parsing `subscribe` and subscribing would fall in
+the gap between the snapshot and the stream and be lost for good; subscribing
+first can at worst duplicate an event the snapshot also carries, and a Consumer
+re-applying the wallpaper it already has is harmless where missing one is not.
+
+## Payload: the whole row, tagged
+
+Rejected: a flat `{id, file_path}`. It is the stated minimum, but a Consumer
+wanting dimensions or tags for a label has to chase the event with a request —
+and an event you must chase is not a push.
+
+Rejected: reusing `DaemonStatus` as the event body. It has no `file_path`,
+which is precisely what `SessionData.setWallpaper()` needs, and it carries
+derived fields (`next_change`, a countdown) that are nonsense frozen into an
+event.
+
+A `Wallpaper` row is ~445 B. At one event per rotation that cost is not worth
+a second round-trip to avoid.
+
+The tag buys room: `mode_changed` and `pause_changed` ship alongside
+`wallpaper_changed` precisely because adding a kind later is
+backwards-compatible while changing a shipped one is not, and a Consumer that
+matches on `event` ignores kinds it does not know.
+
+## Snapshot on connect
+
+Without it a subscriber learns nothing until the next rotation — up to the whole
+rotation interval of staleness on a fresh connection, and worse after a
+reconnect: `DankSocket` redials with backoff up to 15 s, and anything that
+changed in that window would be missed permanently. That is the same class of
+defect the subscription exists to fix, so the stream opens with current state
+rather than pushing the problem onto every Consumer.
+
+The same snapshot is the answer to a lagging subscriber. `tokio::sync::broadcast`
+drops events on behalf of a receiver that falls behind, which leaves it stale in
+ways it cannot detect; on `Lagged` the daemon resends the snapshot instead of
+carrying on from a gap. A slow Consumer is never disconnected for being slow,
+and a slow Consumer can never stall the engine — `broadcast::send` does not
+block, so a subscriber that stops reading parks its own task and nothing else.
+
+## Consequences
+
+`current_wallpaper: Option<String>` on the engine becomes
+`current: Option<Wallpaper>`, written only by `set_current` — the chokepoint
+[#9](../../issues/9) asked for, now load-bearing rather than tidiness: the
+snapshot answers with a `file_path` without going back to the database. Folding
+`last_error = None` into it also fixes a real bug, where a successful
+`SetWallpaper` left a stale failure showing in `status`.
+
+`DaemonStatus` is unchanged. A Consumer can still poll, and the **CLI contract**
+is untouched — a `muralis subscribe` command for shell scripts remains
+worth having and is not needed by any Consumer under
+[ADR 0002](0002-consumers-speak-the-daemon-socket.md).

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,23 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+- **Link parent ↔ child (native sub-issue)**: `gh sub-issue add <parent> <child>` (via `yahsan2/gh-sub-issue` extension; install with `gh extension install yahsan2/gh-sub-issue`). A textual `## Parent #N` reference in the body is NOT enough — the Sub-issues panel only appears when this link is established via API. Fallback when the extension is unavailable: `gh api graphql -f query='mutation { addSubIssue(input:{issueId:"<parent-node-id>", subIssueId:"<child-node-id>"}) { issue { number } } }'` — fetch node IDs with `gh api graphql -f query='query { repository(owner:"<org>",name:"<repo>"){ issue(number:<N>){id} } }'`.
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,17 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Canonical role             | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `afk`                | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+The AFK-ready role maps to `afk` because `~/.local/bin/afk.sh` (and `afk-once.sh`) query `gh issue list --label afk`. That label string is the runner's contract — keep this row in sync with the runner, or AFK-tagged issues silently never get picked up.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/muralis-cli/src/main.rs
+++ b/muralis-cli/src/main.rs
@@ -4,8 +4,8 @@ use serde::Serialize;
 
 use muralis_core::config::Config;
 use muralis_core::db::Database;
-use muralis_core::ipc::{self, IpcRequest, IpcResponse};
-use muralis_core::models::DisplayMode;
+use muralis_core::ipc::{self, FavoritesPage, IpcRequest, IpcResponse};
+use muralis_core::models::{DisplayMode, Wallpaper};
 use muralis_core::paths::MuralisPaths;
 use muralis_core::sources::{AspectRatioFilter, SourceContext, SourceRegistry, WallpaperSource};
 use muralis_core::wallpapers::WallpaperManager;
@@ -275,9 +275,21 @@ async fn main() -> Result<()> {
         }
         Commands::Favorites { action } => match action {
             FavoritesAction::List => {
-                let paths = MuralisPaths::new()?;
-                let db = Database::open(&paths.db_path())?;
-                let wallpapers = db.list_wallpapers()?;
+                // Ask the daemon first — one backing store, one answer — and
+                // read the database ourselves when it cannot answer.
+                let served = ipc::send_request(&IpcRequest::Favorites {
+                    offset: None,
+                    limit: None,
+                })
+                .await;
+                let wallpapers = match library_from_daemon(served) {
+                    Some(wallpapers) => wallpapers,
+                    None => {
+                        let paths = MuralisPaths::new()?;
+                        let db = Database::open(&paths.db_path())?;
+                        db.list_wallpapers()?
+                    }
+                };
                 println!("{}", serde_json::to_string(&wallpapers)?);
             }
             FavoritesAction::Stats => {
@@ -390,6 +402,23 @@ async fn send(request: IpcRequest) -> Result<IpcResponse> {
         .map_err(|e| anyhow::anyhow!("daemon not running. start with: muralis-daemon\n  ({e})"))
 }
 
+/// The **Library** as the daemon served it, or `None` when it did not — no
+/// socket, an error response, or a payload that will not parse. `None` sends
+/// `favorites list` to the database instead: answering with the daemon down is
+/// a **CLI contract** promise the **IPC contract** deliberately does not make
+/// (ADR 0002), so every way the daemon can fail to answer falls back, not just
+/// a refused connection.
+fn library_from_daemon(
+    response: muralis_core::error::Result<IpcResponse>,
+) -> Option<Vec<Wallpaper>> {
+    match response {
+        Ok(IpcResponse::Ok { data: Some(data) }) => serde_json::from_value::<FavoritesPage>(data)
+            .ok()
+            .map(|page| page.wallpapers),
+        _ => None,
+    }
+}
+
 fn print_response(resp: IpcResponse) {
     match resp {
         IpcResponse::Ok { data: Some(data) } => {
@@ -433,5 +462,64 @@ fn format_bytes(bytes: u64) -> String {
         format!("{:.1} KB", bytes as f64 / KB as f64)
     } else {
         format!("{bytes} B")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use muralis_core::ipc::FavoritesPage;
+    use muralis_core::models::{SourceType, Wallpaper};
+
+    fn wallpaper(id: &str) -> Wallpaper {
+        Wallpaper {
+            id: id.into(),
+            source_type: SourceType::new("test"),
+            source_id: id.into(),
+            source_url: None,
+            width: 5120,
+            height: 1440,
+            tags: Vec::new(),
+            file_path: format!("/tmp/{id}.jpg"),
+            added_at: "2026-09-10T00:00:00Z".into(),
+            last_used: None,
+            use_count: 0,
+        }
+    }
+
+    #[test]
+    fn favorites_list_takes_the_library_from_the_daemon_when_it_answers() {
+        let page = FavoritesPage {
+            wallpapers: vec![wallpaper("wp1")],
+            total: 1,
+            offset: 0,
+        };
+        let resp = IpcResponse::ok_with_data(serde_json::to_value(&page).unwrap());
+
+        let library = library_from_daemon(Ok(resp)).expect("a served page is the answer");
+
+        assert_eq!(library.len(), 1);
+        assert_eq!(library[0].id, "wp1");
+    }
+
+    #[test]
+    fn favorites_list_falls_back_when_the_daemon_is_down() {
+        // The CLI contract promises an answer with no daemon; the IPC contract
+        // does not. `None` is the signal to read the database directly.
+        let down = Err(muralis_core::error::MuralisError::Ipc(
+            "failed to connect to daemon".into(),
+        ));
+
+        assert!(library_from_daemon(down).is_none());
+    }
+
+    #[test]
+    fn favorites_list_falls_back_when_the_daemon_answers_badly() {
+        assert!(library_from_daemon(Ok(IpcResponse::error("engine unavailable"))).is_none());
+        assert!(library_from_daemon(Ok(IpcResponse::ok())).is_none());
+        assert!(
+            library_from_daemon(Ok(IpcResponse::ok_with_data(serde_json::json!("nonsense"))))
+                .is_none()
+        );
     }
 }

--- a/muralis-core/Cargo.toml
+++ b/muralis-core/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 serde = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }
+toml_edit = { workspace = true }
 tokio = { workspace = true }
 async-trait = { workspace = true }
 reqwest = { workspace = true }

--- a/muralis-core/src/backend/hyprpaper.rs
+++ b/muralis-core/src/backend/hyprpaper.rs
@@ -67,6 +67,14 @@ impl WallpaperBackend for HyprpaperBackend {
         Ok(())
     }
 
+    /// `hyprctl hyprpaper listactive` exits non-zero until hyprpaper is up
+    /// ("failed to connect to hyprpaper").
+    async fn is_ready(&self) -> Result<()> {
+        Self::hyprctl(&["hyprpaper", "listactive"])
+            .await
+            .map(|_| ())
+    }
+
     fn name(&self) -> &str {
         "hyprpaper"
     }

--- a/muralis-core/src/backend/mod.rs
+++ b/muralis-core/src/backend/mod.rs
@@ -4,6 +4,7 @@ pub mod swww;
 
 use async_trait::async_trait;
 use std::path::Path;
+use std::time::Duration;
 
 use crate::config::Config;
 use crate::error::Result;
@@ -13,12 +14,188 @@ use crate::models::BackendType;
 pub trait WallpaperBackend: Send + Sync {
     async fn set_wallpaper(&self, path: &Path, monitor: &str) -> Result<()>;
     async fn set_wallpaper_all(&self, path: &Path) -> Result<()>;
+
+    /// Probe whether the backend's own daemon is up and accepting requests.
+    /// Every backend here drives a separate long-running process (awww-daemon,
+    /// hyprpaper) that may not have bound its socket yet at login.
+    async fn is_ready(&self) -> Result<()>;
+
     fn name(&self) -> &str;
+}
+
+/// How long to keep probing a backend before giving up on it.
+///
+/// Exists because muralis and the backend daemon are typically launched
+/// together by the compositor with no sequencing: muralis can win the race and,
+/// without waiting, lose its only startup apply of the session.
+#[derive(Debug, Clone)]
+pub struct ReadinessPolicy {
+    /// Maximum number of probes, including the immediate first one.
+    pub attempts: u32,
+    /// Delay before the second probe; doubles each attempt thereafter.
+    pub initial_delay: Duration,
+    /// Ceiling on the doubling.
+    pub max_delay: Duration,
+}
+
+impl Default for ReadinessPolicy {
+    /// ~11s of patience across 10 probes — long enough for a cold login,
+    /// short enough that a genuinely absent backend is reported promptly.
+    fn default() -> Self {
+        Self {
+            attempts: 10,
+            initial_delay: Duration::from_millis(100),
+            max_delay: Duration::from_secs(2),
+        }
+    }
+}
+
+impl ReadinessPolicy {
+    /// Delay before probe `attempt` (0-based). The first probe is immediate.
+    pub fn delay_for(&self, attempt: u32) -> Duration {
+        match attempt.checked_sub(1) {
+            None => Duration::ZERO,
+            Some(shift) => self
+                .initial_delay
+                .checked_mul(1u32.checked_shl(shift).unwrap_or(u32::MAX))
+                .unwrap_or(self.max_delay)
+                .min(self.max_delay),
+        }
+    }
+}
+
+/// Probe `backend` until it reports ready, backing off per `policy`.
+/// Returns the backend's own last error if it never came up.
+pub async fn wait_until_ready(
+    backend: &dyn WallpaperBackend,
+    policy: &ReadinessPolicy,
+) -> Result<()> {
+    let mut last_err = None;
+
+    for attempt in 0..policy.attempts.max(1) {
+        let delay = policy.delay_for(attempt);
+        if !delay.is_zero() {
+            tokio::time::sleep(delay).await;
+        }
+
+        match backend.is_ready().await {
+            Ok(()) => return Ok(()),
+            Err(e) => last_err = Some(e),
+        }
+    }
+
+    Err(last_err.unwrap_or_else(|| {
+        crate::error::MuralisError::Backend(format!("{} never became ready", backend.name()))
+    }))
 }
 
 pub fn create_backend(config: &Config) -> Box<dyn WallpaperBackend> {
     match config.general.backend {
         BackendType::Hyprpaper => Box::new(hyprpaper::HyprpaperBackend::new()),
         BackendType::Swww => Box::new(swww::SwwwBackend::new(config.display.transition.clone())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::MuralisError;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::time::Duration;
+
+    /// Backend that reports ready only from the `ready_at`-th probe onward.
+    /// `ready_at = 0` means never ready.
+    struct ProbeBackend {
+        ready_at: u32,
+        probes: AtomicU32,
+    }
+
+    impl ProbeBackend {
+        fn ready_at(ready_at: u32) -> Self {
+            Self {
+                ready_at,
+                probes: AtomicU32::new(0),
+            }
+        }
+
+        fn probes(&self) -> u32 {
+            self.probes.load(Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait]
+    impl WallpaperBackend for ProbeBackend {
+        async fn set_wallpaper(&self, _path: &Path, _monitor: &str) -> Result<()> {
+            Ok(())
+        }
+
+        async fn set_wallpaper_all(&self, _path: &Path) -> Result<()> {
+            Ok(())
+        }
+
+        async fn is_ready(&self) -> Result<()> {
+            let probe = self.probes.fetch_add(1, Ordering::SeqCst) + 1;
+            if self.ready_at != 0 && probe >= self.ready_at {
+                Ok(())
+            } else {
+                Err(MuralisError::Backend("daemon not listening".into()))
+            }
+        }
+
+        fn name(&self) -> &str {
+            "probe"
+        }
+    }
+
+    /// Policy with the waiting taken out, so tests assert probe counts, not timing.
+    fn no_wait(attempts: u32) -> ReadinessPolicy {
+        ReadinessPolicy {
+            attempts,
+            initial_delay: Duration::ZERO,
+            max_delay: Duration::ZERO,
+        }
+    }
+
+    #[tokio::test]
+    async fn ready_backend_is_probed_once() {
+        let backend = ProbeBackend::ready_at(1);
+        assert!(wait_until_ready(&backend, &no_wait(5)).await.is_ok());
+        assert_eq!(backend.probes(), 1);
+    }
+
+    #[tokio::test]
+    async fn backend_coming_up_late_is_still_caught() {
+        let backend = ProbeBackend::ready_at(3);
+        assert!(wait_until_ready(&backend, &no_wait(5)).await.is_ok());
+        assert_eq!(backend.probes(), 3);
+    }
+
+    #[tokio::test]
+    async fn absent_backend_gives_up_and_reports_its_own_error() {
+        let backend = ProbeBackend::ready_at(0);
+        let err = wait_until_ready(&backend, &no_wait(4)).await.unwrap_err();
+        assert!(
+            err.to_string().contains("daemon not listening"),
+            "expected the backend error to survive, got: {err}"
+        );
+        assert_eq!(backend.probes(), 4);
+    }
+
+    #[test]
+    fn backoff_doubles_up_to_the_ceiling() {
+        let policy = ReadinessPolicy {
+            attempts: 10,
+            initial_delay: Duration::from_millis(100),
+            max_delay: Duration::from_secs(2),
+        };
+
+        // first probe is immediate, then 100ms doubling to the 2s ceiling
+        let delays: Vec<u64> = (0..7)
+            .map(|a| policy.delay_for(a).as_millis() as u64)
+            .collect();
+        assert_eq!(delays, vec![0, 100, 200, 400, 800, 1600, 2000]);
+
+        // no overflow panic once the shift runs past u32
+        assert_eq!(policy.delay_for(64), Duration::from_secs(2));
     }
 }

--- a/muralis-core/src/backend/swww.rs
+++ b/muralis-core/src/backend/swww.rs
@@ -64,6 +64,24 @@ impl WallpaperBackend for SwwwBackend {
         Ok(())
     }
 
+    /// `awww query` fails until awww-daemon has bound its socket.
+    async fn is_ready(&self) -> Result<()> {
+        let output = Command::new("awww")
+            .arg("query")
+            .output()
+            .await
+            .map_err(|e| MuralisError::Backend(format!("failed to run awww: {e}")))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(MuralisError::Backend(format!(
+                "awww-daemon not ready: {}",
+                stderr.trim()
+            )));
+        }
+        Ok(())
+    }
+
     fn name(&self) -> &str {
         "awww"
     }

--- a/muralis-core/src/config.rs
+++ b/muralis-core/src/config.rs
@@ -71,6 +71,20 @@ impl Config {
         }
     }
 
+    /// The modes this config can actually run — `DisplayMode::ALL` minus the
+    /// ones `mode_unavailable_reason` has an answer for.
+    ///
+    /// Derived, never re-encoded: a **Consumer** reads this off `status` to
+    /// offer only what will work, and `SetMode` refuses on the same predicate,
+    /// so the offer and the refusal cannot drift apart.
+    pub fn available_modes(&self) -> Vec<DisplayMode> {
+        DisplayMode::ALL
+            .iter()
+            .copied()
+            .filter(|mode| self.mode_unavailable_reason(*mode).is_none())
+            .collect()
+    }
+
     /// Write `mode` through to `config.toml`, in memory and on disk.
     ///
     /// A mode is a deliberate choice, and the daemon re-reads this file at every
@@ -366,6 +380,41 @@ interval = "15m"   # every quarter hour
             wallpaper: "wp1".into(),
         });
         assert_eq!(config.mode_unavailable_reason(DisplayMode::Workspace), None);
+    }
+
+    #[test]
+    fn the_usable_set_leaves_out_what_the_config_does_not_support() {
+        let config = Config::default();
+        assert_eq!(
+            config.available_modes(),
+            vec![
+                DisplayMode::Static,
+                DisplayMode::Random,
+                DisplayMode::RandomStartup,
+                DisplayMode::Sequential,
+            ],
+            "a Consumer offering schedule or workspace here offers a mode that cannot run"
+        );
+    }
+
+    #[test]
+    fn a_configured_mode_joins_the_usable_set() {
+        let mut config = Config::default();
+        config.schedules.push(ScheduleEntry {
+            time: "08:00".into(),
+            tags: vec!["morning".into()],
+        });
+
+        let modes = config.available_modes();
+
+        assert!(
+            modes.contains(&DisplayMode::Schedule),
+            "one schedule is all schedule mode ever needed"
+        );
+        assert!(
+            !modes.contains(&DisplayMode::Workspace),
+            "workspaces are still empty, so workspace mode is still inert"
+        );
     }
 
     #[test]

--- a/muralis-core/src/config.rs
+++ b/muralis-core/src/config.rs
@@ -55,6 +55,22 @@ impl Config {
         Self::load(paths).unwrap_or_default()
     }
 
+    /// Why `mode` cannot run under this config, or `None` when it can.
+    ///
+    /// The single viability predicate: `SetMode` refuses on `Some` rather than
+    /// reporting success for a mode whose handler would no-op forever, and the
+    /// usable set a **Consumer** reads off `status` is the modes answering
+    /// `None`. Both read it here so the rule exists once.
+    pub fn mode_unavailable_reason(&self, mode: DisplayMode) -> Option<&'static str> {
+        match mode {
+            DisplayMode::Schedule if self.schedules.is_empty() => Some("no schedules configured"),
+            DisplayMode::Workspace if self.workspaces.is_empty() => {
+                Some("no workspaces configured")
+            }
+            _ => None,
+        }
+    }
+
     pub fn save(&self, paths: &MuralisPaths) -> Result<()> {
         let content = toml::to_string_pretty(self)
             .map_err(|e| MuralisError::Config(format!("failed to serialize config: {e}")))?;
@@ -160,6 +176,62 @@ impl Default for FilterConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn schedule_is_unusable_without_schedules() {
+        let config = Config::default();
+        assert_eq!(
+            config.mode_unavailable_reason(DisplayMode::Schedule),
+            Some("no schedules configured"),
+            "schedule mode no-ops forever on an empty schedule list"
+        );
+    }
+
+    #[test]
+    fn schedule_becomes_usable_once_one_is_configured() {
+        let mut config = Config::default();
+        config.schedules.push(ScheduleEntry {
+            time: "08:00".into(),
+            tags: vec!["morning".into()],
+        });
+        assert_eq!(config.mode_unavailable_reason(DisplayMode::Schedule), None);
+    }
+
+    #[test]
+    fn workspace_is_unusable_without_workspaces() {
+        let config = Config::default();
+        assert_eq!(
+            config.mode_unavailable_reason(DisplayMode::Workspace),
+            Some("no workspaces configured"),
+        );
+    }
+
+    #[test]
+    fn workspace_becomes_usable_once_one_is_configured() {
+        let mut config = Config::default();
+        config.workspaces.push(WorkspaceConfig {
+            workspace: 1,
+            wallpaper: "wp1".into(),
+        });
+        assert_eq!(config.mode_unavailable_reason(DisplayMode::Workspace), None);
+    }
+
+    #[test]
+    fn the_rotation_modes_need_no_config_to_run() {
+        let config = Config::default();
+        for mode in [
+            DisplayMode::Static,
+            DisplayMode::Random,
+            DisplayMode::RandomStartup,
+            DisplayMode::Sequential,
+        ] {
+            assert_eq!(
+                config.mode_unavailable_reason(mode),
+                None,
+                "{mode} has no config precondition"
+            );
+        }
+    }
 
     #[test]
     fn test_default_config() {

--- a/muralis-core/src/config.rs
+++ b/muralis-core/src/config.rs
@@ -71,12 +71,52 @@ impl Config {
         }
     }
 
-    pub fn save(&self, paths: &MuralisPaths) -> Result<()> {
-        let content = toml::to_string_pretty(self)
-            .map_err(|e| MuralisError::Config(format!("failed to serialize config: {e}")))?;
+    /// Write `mode` through to `config.toml`, in memory and on disk.
+    ///
+    /// A mode is a deliberate choice, and the daemon re-reads this file at every
+    /// login — leaving it in memory only is how `muralis mode static` evaporates
+    /// at the next reboot with nothing to say it ever happened.
+    ///
+    /// Pause is deliberately *not* written through. Pausing rotation reads as a
+    /// temporary act in a way that choosing a mode does not, so it stays
+    /// ephemeral; the asymmetry is intended, not this fix left half-done.
+    ///
+    /// The edit is surgical: `config.toml` is hand-written, so only the `mode`
+    /// value moves and every comment, key order and bit of spacing around it
+    /// survives. A file that does not parse is refused rather than overwritten.
+    pub fn persist_mode(&mut self, paths: &MuralisPaths, mode: DisplayMode) -> Result<()> {
         let path = paths.config_file();
-        std::fs::write(&path, content)
-            .map_err(|e| MuralisError::Config(format!("failed to write {}: {e}", path.display())))
+
+        let content = match std::fs::read_to_string(&path) {
+            Ok(content) => content,
+            // No config file yet is not an error: the daemon runs on defaults,
+            // and the choice still has to outlive the process.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+            Err(e) => {
+                return Err(MuralisError::Config(format!(
+                    "failed to read {}: {e}",
+                    path.display()
+                )))
+            }
+        };
+
+        let mut doc = content.parse::<toml_edit::DocumentMut>().map_err(|e| {
+            MuralisError::Config(format!("failed to parse {}: {e}", path.display()))
+        })?;
+
+        doc["display"]["mode"] = toml_edit::value(mode.to_string());
+
+        if let Some(dir) = path.parent() {
+            std::fs::create_dir_all(dir).map_err(|e| {
+                MuralisError::Config(format!("failed to create {}: {e}", dir.display()))
+            })?;
+        }
+        std::fs::write(&path, doc.to_string()).map_err(|e| {
+            MuralisError::Config(format!("failed to write {}: {e}", path.display()))
+        })?;
+
+        self.display.mode = mode;
+        Ok(())
     }
 }
 
@@ -176,6 +216,118 @@ impl Default for FilterConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A throwaway XDG root holding `content` as config.toml (none when `None`).
+    fn paths_with(content: Option<&str>) -> (MuralisPaths, tempfile::TempDir) {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = MuralisPaths {
+            config_dir: tmp.path().join("config"),
+            data_dir: tmp.path().join("data"),
+            cache_dir: tmp.path().join("cache"),
+        };
+        paths.ensure_dirs().unwrap();
+        if let Some(content) = content {
+            std::fs::write(paths.config_file(), content).unwrap();
+        }
+        (paths, tmp)
+    }
+
+    #[test]
+    fn a_persisted_mode_survives_a_restart() {
+        let (paths, _tmp) = paths_with(Some("[display]\nmode = \"random_startup\"\n"));
+        let mut config = Config::load(&paths).unwrap();
+
+        config.persist_mode(&paths, DisplayMode::Static).unwrap();
+
+        assert_eq!(
+            Config::load(&paths).unwrap().display.mode,
+            DisplayMode::Static,
+            "the daemon reads config.toml at next login; the choice has to be in it"
+        );
+        assert_eq!(
+            config.display.mode,
+            DisplayMode::Static,
+            "the in-memory config must not disagree with the file it was just written to"
+        );
+    }
+
+    #[test]
+    fn persisting_a_mode_leaves_the_hand_edits_around_it_alone() {
+        let original = r#"# my wallpaper setup
+[general]
+backend = "swww"   # trailing note
+
+[display]
+mode  = "random"
+interval = "15m"   # every quarter hour
+"#;
+        let (paths, _tmp) = paths_with(Some(original));
+        let mut config = Config::load(&paths).unwrap();
+
+        config
+            .persist_mode(&paths, DisplayMode::Sequential)
+            .unwrap();
+
+        let written = std::fs::read_to_string(paths.config_file()).unwrap();
+        assert!(
+            written.contains("# my wallpaper setup"),
+            "a whole-file reserialize would drop the comments: {written}"
+        );
+        assert!(written.contains("backend = \"swww\"   # trailing note"));
+        assert!(written.contains("interval = \"15m\"   # every quarter hour"));
+        assert!(
+            written.contains("mode  = \"sequential\""),
+            "only the value changes, not the spacing the user chose: {written}"
+        );
+    }
+
+    #[test]
+    fn a_config_with_no_display_section_gains_one() {
+        let (paths, _tmp) = paths_with(Some("[general]\nbackend = \"swww\"\n"));
+        let mut config = Config::load(&paths).unwrap();
+
+        config.persist_mode(&paths, DisplayMode::Workspace).unwrap();
+
+        let reloaded = Config::load(&paths).unwrap();
+        assert_eq!(reloaded.display.mode, DisplayMode::Workspace);
+        assert_eq!(
+            reloaded.general.backend,
+            BackendType::Swww,
+            "the section we added must not disturb the one that was there"
+        );
+    }
+
+    #[test]
+    fn a_missing_config_file_is_created_rather_than_losing_the_choice() {
+        let (paths, _tmp) = paths_with(None);
+        let mut config = Config::default();
+
+        config.persist_mode(&paths, DisplayMode::Static).unwrap();
+
+        assert_eq!(
+            Config::load(&paths).unwrap().display.mode,
+            DisplayMode::Static
+        );
+    }
+
+    #[test]
+    fn a_config_that_does_not_parse_is_left_untouched() {
+        let broken = "[display\nmode = \"random\"\n";
+        let (paths, _tmp) = paths_with(Some(broken));
+        let mut config = Config::default();
+
+        let result = config.persist_mode(&paths, DisplayMode::Static);
+
+        assert!(
+            result.is_err(),
+            "a file we cannot parse is not one we can edit"
+        );
+        assert_eq!(
+            std::fs::read_to_string(paths.config_file()).unwrap(),
+            broken,
+            "refusing must not cost the user the config they have"
+        );
+    }
 
     #[test]
     fn schedule_is_unusable_without_schedules() {

--- a/muralis-core/src/ipc.rs
+++ b/muralis-core/src/ipc.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::error::{MuralisError, Result};
-use crate::models::DisplayMode;
+use crate::models::{DisplayMode, Wallpaper};
 use crate::paths::MuralisPaths;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -29,7 +29,40 @@ pub enum IpcRequest {
     Pause,
     Resume,
     Reload,
+    /// Hold the connection open and stream `DaemonEvent` lines until the
+    /// Consumer hangs up. Unlike every other variant this gets no
+    /// `IpcResponse`: the first lines back are a **snapshot** of daemon state
+    /// as events, so a Consumer that just reconnected is current without a
+    /// follow-up round-trip.
+    Subscribe,
     Quit,
+}
+
+/// One line of the **subscription**: something the daemon did, pushed to every
+/// **Consumer** holding a `Subscribe` connection open.
+///
+/// Tagged like `IpcRequest` so a Consumer switches on one field, and carries
+/// everything needed to act — `WallpaperChanged` holds the whole `Wallpaper`
+/// row because `SessionData.setWallpaper()` wants a path, and asking `Status`
+/// for it would defeat the point of pushing. Adding a variant is
+/// backwards-compatible; changing a shipped one is not.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub enum DaemonEvent {
+    /// A wallpaper reached the screen. Emitted only on a successful apply —
+    /// a failed one leaves the previous wallpaper up, and saying otherwise
+    /// would have a Consumer regenerate its palette from an image nobody sees.
+    /// Boxed only to keep the variants a similar size — `Box<T>` serializes
+    /// as the row itself, so the wire shape is unaffected.
+    WallpaperChanged {
+        wallpaper: Box<Wallpaper>,
+    },
+    ModeChanged {
+        mode: DisplayMode,
+    },
+    PauseChanged {
+        paused: bool,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -236,6 +269,62 @@ mod tests {
     }
 
     #[test]
+    fn subscribe_is_a_bare_command_like_the_one_shots() {
+        let req: IpcRequest = serde_json::from_str(r#"{"command":"subscribe"}"#).unwrap();
+        assert!(matches!(req, IpcRequest::Subscribe));
+        assert_eq!(
+            serde_json::to_string(&IpcRequest::Subscribe).unwrap(),
+            r#"{"command":"subscribe"}"#
+        );
+    }
+
+    #[test]
+    fn a_wallpaper_event_carries_the_path_without_a_follow_up_request() {
+        // The DMS Widget hands `file_path` straight to `setWallpaper()`; an
+        // event it has to chase with a `Status` is not a push.
+        let event = DaemonEvent::WallpaperChanged {
+            wallpaper: Box::new(Wallpaper {
+                id: "abc123".into(),
+                source_type: crate::models::SourceType::new("wallhaven"),
+                source_id: "x7k2m".into(),
+                source_url: None,
+                width: 3840,
+                height: 2160,
+                tags: vec!["night".into()],
+                file_path: "/home/u/.local/share/muralis/wallpapers/abc123.jpg".into(),
+                added_at: "2026-09-10T00:00:00Z".into(),
+                last_used: None,
+                use_count: 0,
+            }),
+        };
+
+        let json = serde_json::to_string(&event).unwrap();
+
+        assert!(
+            json.starts_with(r#"{"event":"wallpaper_changed","wallpaper":{"#),
+            "unexpected wire shape: {json}"
+        );
+        assert!(
+            json.contains(r#""file_path":"/home/u/.local/share/muralis/wallpapers/abc123.jpg""#)
+        );
+    }
+
+    #[test]
+    fn the_other_event_kinds_name_themselves_the_same_way() {
+        assert_eq!(
+            serde_json::to_string(&DaemonEvent::ModeChanged {
+                mode: DisplayMode::Sequential
+            })
+            .unwrap(),
+            r#"{"event":"mode_changed","mode":"sequential"}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&DaemonEvent::PauseChanged { paused: true }).unwrap(),
+            r#"{"event":"pause_changed","paused":true}"#
+        );
+    }
+
+    #[test]
     fn test_roundtrip_all_requests() {
         let requests = vec![
             IpcRequest::Status,
@@ -248,6 +337,7 @@ mod tests {
             IpcRequest::Pause,
             IpcRequest::Resume,
             IpcRequest::Reload,
+            IpcRequest::Subscribe,
             IpcRequest::Quit,
         ];
 

--- a/muralis-core/src/ipc.rs
+++ b/muralis-core/src/ipc.rs
@@ -38,6 +38,10 @@ pub struct DaemonStatus {
     pub current_wallpaper: Option<String>,
     pub wallpaper_count: u32,
     pub next_change: Option<String>,
+    /// Why the last wallpaper apply failed, if it did. `None` once one
+    /// succeeds. A Consumer reads this to tell "nothing applied yet" apart from
+    /// "the backend refused" — the failure used to be a `warn!` nobody saw.
+    pub last_error: Option<String>,
 }
 
 impl IpcResponse {
@@ -134,6 +138,7 @@ mod tests {
             current_wallpaper: Some("abc123".into()),
             wallpaper_count: 42,
             next_change: Some("2025-01-01T01:00:00Z".into()),
+            last_error: None,
         };
         let data = serde_json::to_value(&status).unwrap();
         let resp = IpcResponse::ok_with_data(data);

--- a/muralis-core/src/ipc.rs
+++ b/muralis-core/src/ipc.rs
@@ -122,6 +122,23 @@ impl IpcResponse {
     }
 }
 
+/// Why a dial failed, in terms the person running the command can act on.
+///
+/// `ENOENT` and `ECONNREFUSED` are different facts — nothing ever bound the
+/// path, versus a socket file outliving the daemon that made it — but they are
+/// the same situation: no daemon is answering. Reporting the errno taught
+/// nobody anything, so both become one sentence naming the socket, and every
+/// other failure keeps the underlying error, which is the case where the
+/// detail is the whole message.
+fn connect_error(socket_path: &std::path::Path, error: std::io::Error) -> MuralisError {
+    match error.kind() {
+        std::io::ErrorKind::NotFound | std::io::ErrorKind::ConnectionRefused => MuralisError::Ipc(
+            format!("muralis daemon is not running ({})", socket_path.display()),
+        ),
+        _ => MuralisError::Ipc(format!("failed to connect to daemon: {error}")),
+    }
+}
+
 /// Send a request to the daemon and receive a response.
 pub async fn send_request(request: &IpcRequest) -> Result<IpcResponse> {
     use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -130,7 +147,7 @@ pub async fn send_request(request: &IpcRequest) -> Result<IpcResponse> {
     let socket_path = MuralisPaths::socket_path();
     let stream = UnixStream::connect(&socket_path)
         .await
-        .map_err(|e| MuralisError::Ipc(format!("failed to connect to daemon: {e}")))?;
+        .map_err(|e| connect_error(&socket_path, e))?;
 
     let (reader, mut writer) = stream.into_split();
 
@@ -321,6 +338,38 @@ mod tests {
         assert_eq!(
             serde_json::to_string(&DaemonEvent::PauseChanged { paused: true }).unwrap(),
             r#"{"event":"pause_changed","paused":true}"#
+        );
+    }
+
+    #[test]
+    fn a_daemon_that_is_not_there_says_so_rather_than_reporting_an_errno() {
+        // Both of these mean "no daemon". Which errno got there first is not
+        // something the person running `muralis status` can act on.
+        for kind in [
+            std::io::ErrorKind::NotFound,
+            std::io::ErrorKind::ConnectionRefused,
+        ] {
+            let error = connect_error(
+                std::path::Path::new("/tmp/muralis-1000.sock"),
+                std::io::Error::new(kind, "whatever the kernel called it"),
+            );
+            assert_eq!(
+                error.to_string(),
+                "ipc error: muralis daemon is not running (/tmp/muralis-1000.sock)",
+                "unexpected message for {kind:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_unexpected_failure_keeps_the_detail() {
+        let error = connect_error(
+            std::path::Path::new("/tmp/muralis-1000.sock"),
+            std::io::Error::new(std::io::ErrorKind::PermissionDenied, "permission denied"),
+        );
+        assert!(
+            error.to_string().contains("permission denied"),
+            "a failure we have no better words for must not lose them: {error}"
         );
     }
 

--- a/muralis-core/src/ipc.rs
+++ b/muralis-core/src/ipc.rs
@@ -10,8 +10,22 @@ pub enum IpcRequest {
     Status,
     Next,
     Prev,
-    SetWallpaper { id: String },
-    SetMode { mode: DisplayMode },
+    SetWallpaper {
+        id: String,
+    },
+    SetMode {
+        mode: DisplayMode,
+    },
+    /// The **Library** — every kept wallpaper. A bare `favorites` asks for all
+    /// of it; `offset`/`limit` window it for a Consumer that draws a page at a
+    /// time. A row serializes to ~445 B, so a 1000-wallpaper Library is a
+    /// ~435 KiB single socket line, against ~7 KiB for a 16-item grid page.
+    Favorites {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        offset: Option<u32>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        limit: Option<u32>,
+    },
     Pause,
     Resume,
     Reload,
@@ -42,6 +56,15 @@ pub struct DaemonStatus {
     /// succeeds. A Consumer reads this to tell "nothing applied yet" apart from
     /// "the backend refused" — the failure used to be a `warn!` nobody saw.
     pub last_error: Option<String>,
+}
+
+/// The `Favorites` response: one window onto the **Library**, plus the total so
+/// a Consumer can size its scrollbar without asking for everything.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FavoritesPage {
+    pub wallpapers: Vec<crate::models::Wallpaper>,
+    pub total: u32,
+    pub offset: u32,
 }
 
 impl IpcResponse {
@@ -145,6 +168,41 @@ mod tests {
         let json = serde_json::to_string(&resp).unwrap();
         assert!(json.contains("abc123"));
         assert!(json.contains("42"));
+    }
+
+    #[test]
+    fn favorites_asks_for_the_whole_library_by_default() {
+        // The CLI contract is "the whole Library"; paging is the Consumer's
+        // opt-in, so the bare command must carry no window at all.
+        let json = r#"{"command":"favorites"}"#;
+        let req: IpcRequest = serde_json::from_str(json).unwrap();
+        assert!(matches!(
+            req,
+            IpcRequest::Favorites {
+                offset: None,
+                limit: None
+            }
+        ));
+
+        let line = serde_json::to_string(&IpcRequest::Favorites {
+            offset: None,
+            limit: None,
+        })
+        .unwrap();
+        assert_eq!(line, r#"{"command":"favorites"}"#);
+    }
+
+    #[test]
+    fn favorites_carries_a_window_when_a_consumer_pages() {
+        let json = r#"{"command":"favorites","offset":32,"limit":16}"#;
+        let req: IpcRequest = serde_json::from_str(json).unwrap();
+        assert!(matches!(
+            req,
+            IpcRequest::Favorites {
+                offset: Some(32),
+                limit: Some(16)
+            }
+        ));
     }
 
     #[test]

--- a/muralis-core/src/ipc.rs
+++ b/muralis-core/src/ipc.rs
@@ -52,6 +52,12 @@ pub struct DaemonStatus {
     pub current_wallpaper: Option<String>,
     pub wallpaper_count: u32,
     pub next_change: Option<String>,
+    /// The modes this daemon's config can actually run
+    /// (`Config::available_modes`). A Consumer offers these and greys out the
+    /// rest rather than presenting six equal choices of which two would
+    /// silently stop the wallpaper changing; one that ignores the field
+    /// behaves as before, and the daemon refuses an unusable mode regardless.
+    pub available_modes: Vec<DisplayMode>,
     /// Why the last wallpaper apply failed, if it did. `None` once one
     /// succeeds. A Consumer reads this to tell "nothing applied yet" apart from
     /// "the backend refused" — the failure used to be a `warn!` nobody saw.
@@ -162,12 +168,36 @@ mod tests {
             wallpaper_count: 42,
             next_change: Some("2025-01-01T01:00:00Z".into()),
             last_error: None,
+            available_modes: vec![DisplayMode::Static, DisplayMode::Random],
         };
         let data = serde_json::to_value(&status).unwrap();
         let resp = IpcResponse::ok_with_data(data);
         let json = serde_json::to_string(&resp).unwrap();
         assert!(json.contains("abc123"));
         assert!(json.contains("42"));
+    }
+
+    #[test]
+    fn status_names_the_usable_modes_on_the_wire() {
+        // A Consumer greys out its switcher off this array, so the names have
+        // to be the ones `SetMode` accepts back.
+        let status = DaemonStatus {
+            running: true,
+            mode: DisplayMode::Random,
+            paused: false,
+            current_wallpaper: None,
+            wallpaper_count: 0,
+            next_change: None,
+            available_modes: vec![DisplayMode::RandomStartup, DisplayMode::Schedule],
+            last_error: None,
+        };
+
+        let json = serde_json::to_string(&status).unwrap();
+
+        assert!(
+            json.contains(r#""available_modes":["random_startup","schedule"]"#),
+            "unexpected wire shape: {json}"
+        );
     }
 
     #[test]

--- a/muralis-daemon/Cargo.toml
+++ b/muralis-daemon/Cargo.toml
@@ -15,3 +15,7 @@ hyprland = { workspace = true }
 rand = { workspace = true }
 chrono = { workspace = true }
 futures-lite = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"
+async-trait = { workspace = true }

--- a/muralis-daemon/src/display/engine.rs
+++ b/muralis-daemon/src/display/engine.rs
@@ -255,10 +255,21 @@ impl DisplayEngine {
     /// missing. `schedule` with no schedules and `workspace` with no workspaces
     /// have handlers that no-op forever: reporting success there means the
     /// wallpaper silently stops changing with nothing to connect it to.
+    ///
+    /// The choice is written through to `config.toml` before it takes effect,
+    /// so the running mode and the one the next daemon boots into cannot
+    /// disagree — a failed write is reported rather than leaving a mode that
+    /// works now and reverts at reboot. Pause and resume stay ephemeral on
+    /// purpose; see `Config::persist_mode`.
     fn set_mode(&mut self, mode: DisplayMode) -> Result<(), String> {
         if let Some(reason) = self.config.mode_unavailable_reason(mode) {
             warn!(mode = %mode, reason, "refused a mode that cannot run");
             return Err(reason.to_string());
+        }
+
+        if let Err(e) = self.config.persist_mode(&self.paths, mode) {
+            warn!(mode = %mode, "failed to persist display mode: {e}");
+            return Err(format!("could not save mode: {e}"));
         }
 
         info!(mode = %mode, "display mode changed");
@@ -529,6 +540,53 @@ mod tests {
 
         assert!(engine.set_mode(DisplayMode::Sequential).is_ok());
         assert_eq!(engine.mode, DisplayMode::Sequential);
+    }
+
+    #[tokio::test]
+    async fn a_chosen_mode_outlives_the_daemon_that_was_told_about_it() {
+        let (mut engine, _tmp) = engine_with(FakeBackend::ready_at(1));
+
+        engine.set_mode(DisplayMode::Sequential).unwrap();
+
+        assert_eq!(
+            Config::load(&engine.paths).unwrap().display.mode,
+            DisplayMode::Sequential,
+            "the next daemon reads config.toml, so an unwritten mode change is a lost one"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_refused_mode_is_never_written_to_the_config() {
+        let (mut engine, _tmp) = engine_with(FakeBackend::ready_at(1));
+        let original = "[display]\nmode = \"random\"\n";
+        std::fs::write(engine.paths.config_file(), original).unwrap();
+
+        assert!(engine.set_mode(DisplayMode::Schedule).is_err());
+
+        assert_eq!(
+            std::fs::read_to_string(engine.paths.config_file()).unwrap(),
+            original,
+            "a mode the daemon refuses must not be the one it boots into"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_config_that_cannot_be_written_leaves_the_mode_where_it_was() {
+        let (mut engine, _tmp) = engine_with(FakeBackend::ready_at(1));
+        // A directory where the file belongs: writable path, unwritable file.
+        std::fs::create_dir_all(engine.paths.config_file()).unwrap();
+        let before = engine.mode;
+
+        let result = engine.set_mode(DisplayMode::Sequential);
+
+        assert!(
+            result.is_err(),
+            "a mode we cannot persist is one we do not claim"
+        );
+        assert_eq!(
+            engine.mode, before,
+            "reporting success for a change that reverts at reboot is the bug being fixed"
+        );
     }
 
     #[tokio::test]

--- a/muralis-daemon/src/display/engine.rs
+++ b/muralis-daemon/src/display/engine.rs
@@ -9,7 +9,7 @@ use muralis_core::backend::{wait_until_ready, ReadinessPolicy, WallpaperBackend}
 use muralis_core::cache;
 use muralis_core::config::Config;
 use muralis_core::db::Database;
-use muralis_core::ipc::DaemonStatus;
+use muralis_core::ipc::{DaemonStatus, FavoritesPage};
 use muralis_core::models::{DisplayMode, Wallpaper};
 use muralis_core::paths::MuralisPaths;
 
@@ -112,6 +112,9 @@ impl DisplayEngine {
                             self.prev().await;
                             self.update_next_change(tick_duration);
                             timer.reset();
+                        }
+                        DaemonCommand::Favorites { offset, limit, respond } => {
+                            let _ = respond.send(self.favorites(offset, limit));
                         }
                         DaemonCommand::SetWallpaper { id, respond } => {
                             let result = self.set_wallpaper(&id).await;
@@ -275,6 +278,27 @@ impl DisplayEngine {
         info!(mode = %mode, "display mode changed");
         self.mode = mode;
         Ok(())
+    }
+
+    /// One window onto the **Library**, read from the store rather than the
+    /// engine's rotation cache: `favorites add` writes the DB directly, so a
+    /// Consumer asking right after favoriting would otherwise miss its own
+    /// wallpaper until the next reload.
+    fn favorites(&self, offset: Option<u32>, limit: Option<u32>) -> Result<FavoritesPage, String> {
+        let db = Database::open(&self.paths.db_path()).map_err(|e| e.to_string())?;
+        let all = db.list_wallpapers().map_err(|e| e.to_string())?;
+        let total = all.len() as u32;
+        let offset = offset.unwrap_or(0);
+        let wallpapers = all
+            .into_iter()
+            .skip(offset as usize)
+            .take(limit.map_or(usize::MAX, |l| l as usize))
+            .collect();
+        Ok(FavoritesPage {
+            wallpapers,
+            total,
+            offset,
+        })
     }
 
     async fn set_wallpaper(&mut self, id: &str) -> muralis_core::error::Result<()> {
@@ -495,6 +519,85 @@ mod tests {
         }];
 
         (engine, tmp)
+    }
+
+    /// Rows in the engine's own store, `added_at` descending like the DB
+    /// orders them, so `wp0` is newest.
+    fn seed_library(engine: &DisplayEngine, count: u32) {
+        let db = Database::open(&engine.paths.db_path()).unwrap();
+        for i in 0..count {
+            db.insert_wallpaper(&Wallpaper {
+                id: format!("wp{i}"),
+                source_type: SourceType::new("test"),
+                source_id: format!("wp{i}"),
+                source_url: None,
+                width: 5120,
+                height: 1440,
+                tags: Vec::new(),
+                file_path: format!("/tmp/wp{i}.jpg"),
+                added_at: format!("2026-09-{:02}T00:00:00Z", 30 - i),
+                last_used: None,
+                use_count: 0,
+            })
+            .unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn favorites_serves_the_library_from_the_store_not_a_stale_cache() {
+        let (engine, _tmp) = engine_with(FakeBackend::ready_at(1));
+        // `favorites add` writes the DB behind the daemon's back; a Consumer
+        // that just favorited must see it without a reload.
+        seed_library(&engine, 3);
+
+        let page = engine.favorites(None, None).unwrap();
+
+        assert_eq!(page.total, 3);
+        assert_eq!(page.offset, 0);
+        assert_eq!(
+            page.wallpapers
+                .iter()
+                .map(|w| w.id.as_str())
+                .collect::<Vec<_>>(),
+            ["wp0", "wp1", "wp2"],
+            "the whole Library, newest first"
+        );
+    }
+
+    #[tokio::test]
+    async fn favorites_windows_the_library_for_a_paging_consumer() {
+        let (engine, _tmp) = engine_with(FakeBackend::ready_at(1));
+        seed_library(&engine, 5);
+
+        let page = engine.favorites(Some(2), Some(2)).unwrap();
+
+        assert_eq!(
+            page.wallpapers
+                .iter()
+                .map(|w| w.id.as_str())
+                .collect::<Vec<_>>(),
+            ["wp2", "wp3"],
+            "the window starts at the offset and is no longer than the limit"
+        );
+        assert_eq!(page.offset, 2, "the window says where it sits");
+        assert_eq!(
+            page.total, 5,
+            "total counts the whole Library, not the page"
+        );
+    }
+
+    #[tokio::test]
+    async fn favorites_past_the_end_is_an_empty_page_not_an_error() {
+        let (engine, _tmp) = engine_with(FakeBackend::ready_at(1));
+        seed_library(&engine, 3);
+
+        let page = engine.favorites(Some(10), Some(16)).unwrap();
+
+        assert!(page.wallpapers.is_empty());
+        assert_eq!(
+            page.total, 3,
+            "a Consumer scrolling past the end still learns the size"
+        );
     }
 
     #[tokio::test]

--- a/muralis-daemon/src/display/engine.rs
+++ b/muralis-daemon/src/display/engine.rs
@@ -414,6 +414,7 @@ impl DisplayEngine {
                 format!("{}s", remaining.as_secs())
             }),
             last_error: self.last_error.clone(),
+            available_modes: self.config.available_modes(),
         }
     }
 
@@ -643,6 +644,26 @@ mod tests {
 
         assert!(engine.set_mode(DisplayMode::Sequential).is_ok());
         assert_eq!(engine.mode, DisplayMode::Sequential);
+    }
+
+    #[tokio::test]
+    async fn status_offers_only_the_modes_this_config_can_run() {
+        let (mut engine, _tmp) = engine_with(FakeBackend::ready_at(1));
+        engine.config.schedules.push(ScheduleEntry {
+            time: "08:00".into(),
+            tags: vec!["morning".into()],
+        });
+
+        let status = engine.status();
+
+        assert!(
+            status.available_modes.contains(&DisplayMode::Schedule),
+            "a schedule is configured, so schedule mode is on offer"
+        );
+        assert!(
+            !status.available_modes.contains(&DisplayMode::Workspace),
+            "workspace mode would no-op forever here; a Consumer must be able to tell"
+        );
     }
 
     #[tokio::test]

--- a/muralis-daemon/src/display/engine.rs
+++ b/muralis-daemon/src/display/engine.rs
@@ -117,9 +117,9 @@ impl DisplayEngine {
                             let result = self.set_wallpaper(&id).await;
                             let _ = respond.send(result.map_err(|e| e.to_string()));
                         }
-                        DaemonCommand::SetMode { mode } => {
-                            info!(mode = %mode, "display mode changed");
-                            self.mode = mode;
+                        DaemonCommand::SetMode { mode, respond } => {
+                            let result = self.set_mode(mode);
+                            let _ = respond.send(result);
                         }
                         DaemonCommand::Pause => {
                             self.paused = true;
@@ -249,6 +249,21 @@ impl DisplayEngine {
                 self.last_error = Some(format!("wallpaper file missing: {}", path.display()));
             }
         }
+    }
+
+    /// Switch the display mode, refusing one whose config precondition is
+    /// missing. `schedule` with no schedules and `workspace` with no workspaces
+    /// have handlers that no-op forever: reporting success there means the
+    /// wallpaper silently stops changing with nothing to connect it to.
+    fn set_mode(&mut self, mode: DisplayMode) -> Result<(), String> {
+        if let Some(reason) = self.config.mode_unavailable_reason(mode) {
+            warn!(mode = %mode, reason, "refused a mode that cannot run");
+            return Err(reason.to_string());
+        }
+
+        info!(mode = %mode, "display mode changed");
+        self.mode = mode;
+        Ok(())
     }
 
     async fn set_wallpaper(&mut self, id: &str) -> muralis_core::error::Result<()> {
@@ -381,6 +396,7 @@ mod tests {
     use super::*;
     use async_trait::async_trait;
     use muralis_core::backend::ReadinessPolicy;
+    use muralis_core::config::ScheduleEntry;
     use muralis_core::error::{MuralisError, Result};
     use muralis_core::models::SourceType;
     use std::sync::atomic::{AtomicU32, Ordering};
@@ -468,6 +484,51 @@ mod tests {
         }];
 
         (engine, tmp)
+    }
+
+    #[tokio::test]
+    async fn set_mode_refuses_a_mode_that_cannot_possibly_run() {
+        let (mut engine, _tmp) = engine_with(FakeBackend::ready_at(1));
+        let before = engine.mode;
+
+        let result = engine.set_mode(DisplayMode::Schedule);
+
+        assert_eq!(
+            result.err().as_deref(),
+            Some("no schedules configured"),
+            "an empty schedule list makes schedule mode inert, so the change must fail loudly"
+        );
+        assert_eq!(engine.mode, before, "the previous mode stays in effect");
+    }
+
+    #[tokio::test]
+    async fn set_mode_refuses_workspace_without_workspaces() {
+        let (mut engine, _tmp) = engine_with(FakeBackend::ready_at(1));
+
+        let result = engine.set_mode(DisplayMode::Workspace);
+
+        assert_eq!(result.err().as_deref(), Some("no workspaces configured"));
+        assert_ne!(engine.mode, DisplayMode::Workspace);
+    }
+
+    #[tokio::test]
+    async fn set_mode_accepts_a_configured_mode() {
+        let (mut engine, _tmp) = engine_with(FakeBackend::ready_at(1));
+        engine.config.schedules.push(ScheduleEntry {
+            time: "08:00".into(),
+            tags: vec!["morning".into()],
+        });
+
+        assert!(engine.set_mode(DisplayMode::Schedule).is_ok());
+        assert_eq!(engine.mode, DisplayMode::Schedule);
+    }
+
+    #[tokio::test]
+    async fn set_mode_accepts_a_mode_with_no_precondition() {
+        let (mut engine, _tmp) = engine_with(FakeBackend::ready_at(1));
+
+        assert!(engine.set_mode(DisplayMode::Sequential).is_ok());
+        assert_eq!(engine.mode, DisplayMode::Sequential);
     }
 
     #[tokio::test]

--- a/muralis-daemon/src/display/engine.rs
+++ b/muralis-daemon/src/display/engine.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::time::Duration;
 
-use tokio::sync::mpsc;
+use tokio::sync::{broadcast, mpsc};
 use tokio::time::{interval, Instant, MissedTickBehavior};
 use tracing::{info, warn};
 
@@ -9,7 +9,7 @@ use muralis_core::backend::{wait_until_ready, ReadinessPolicy, WallpaperBackend}
 use muralis_core::cache;
 use muralis_core::config::Config;
 use muralis_core::db::Database;
-use muralis_core::ipc::{DaemonStatus, FavoritesPage};
+use muralis_core::ipc::{DaemonEvent, DaemonStatus, FavoritesPage};
 use muralis_core::models::{DisplayMode, Wallpaper};
 use muralis_core::paths::MuralisPaths;
 
@@ -23,15 +23,24 @@ pub struct DisplayEngine {
     mode: DisplayMode,
     paused: bool,
     current_index: usize,
-    current_wallpaper: Option<String>,
+    /// What is actually on screen — the whole row, not just its id, so a
+    /// subscriber's snapshot can answer with a `file_path` without going back
+    /// to the database. Only `set_current` writes it.
+    current: Option<Wallpaper>,
     wallpapers: Vec<Wallpaper>,
     next_change: Option<Instant>,
     last_error: Option<String>,
     readiness: ReadinessPolicy,
+    events: broadcast::Sender<DaemonEvent>,
 }
 
 impl DisplayEngine {
-    pub fn new(config: Config, paths: MuralisPaths, backend: Box<dyn WallpaperBackend>) -> Self {
+    pub fn new(
+        config: Config,
+        paths: MuralisPaths,
+        backend: Box<dyn WallpaperBackend>,
+        events: broadcast::Sender<DaemonEvent>,
+    ) -> Self {
         let mode = config.display.mode;
         Self {
             config,
@@ -40,12 +49,50 @@ impl DisplayEngine {
             mode,
             paused: false,
             current_index: 0,
-            current_wallpaper: None,
+            current: None,
             wallpapers: Vec::new(),
             next_change: None,
             last_error: None,
             readiness: ReadinessPolicy::default(),
+            events,
         }
+    }
+
+    /// The one place `current` is written. Three call sites used to assign it
+    /// independently — a timed rotation, a `SetWallpaper`, a workspace switch —
+    /// and only two of them cleared `last_error`. Routing them all through here
+    /// means "what is on screen" has a single definition, and every way of
+    /// changing it reaches subscribers.
+    fn set_current(&mut self, wp: &Wallpaper) {
+        self.current = Some(wp.clone());
+        self.last_error = None;
+        self.emit(DaemonEvent::WallpaperChanged {
+            wallpaper: Box::new(wp.clone()),
+        });
+    }
+
+    /// Push one event to every open subscription. `send` never blocks and
+    /// fails only when nobody is subscribed — the common case, and not an
+    /// error. A subscriber too slow to keep up has events dropped on its
+    /// behalf and is resynced from a snapshot; it cannot stall the engine.
+    fn emit(&self, event: DaemonEvent) {
+        let _ = self.events.send(event);
+    }
+
+    /// Current state as the events that would have produced it, for a
+    /// subscriber that just connected.
+    fn snapshot(&self) -> Vec<DaemonEvent> {
+        let mut events = Vec::with_capacity(3);
+        if let Some(wp) = &self.current {
+            events.push(DaemonEvent::WallpaperChanged {
+                wallpaper: Box::new(wp.clone()),
+            });
+        }
+        events.push(DaemonEvent::ModeChanged { mode: self.mode });
+        events.push(DaemonEvent::PauseChanged {
+            paused: self.paused,
+        });
+        events
     }
 
     pub async fn run(
@@ -113,6 +160,9 @@ impl DisplayEngine {
                             self.update_next_change(tick_duration);
                             timer.reset();
                         }
+                        DaemonCommand::Snapshot { respond } => {
+                            let _ = respond.send(self.snapshot());
+                        }
                         DaemonCommand::Favorites { offset, limit, respond } => {
                             let _ = respond.send(self.favorites(offset, limit));
                         }
@@ -126,10 +176,12 @@ impl DisplayEngine {
                         }
                         DaemonCommand::Pause => {
                             self.paused = true;
+                            self.emit(DaemonEvent::PauseChanged { paused: true });
                             info!("rotation paused");
                         }
                         DaemonCommand::Resume => {
                             self.paused = false;
+                            self.emit(DaemonEvent::PauseChanged { paused: false });
                             self.update_next_change(tick_duration);
                             timer.reset();
                             info!("rotation resumed");
@@ -231,8 +283,8 @@ impl DisplayEngine {
             if path.exists() {
                 match self.backend.set_wallpaper_all(path).await {
                     Ok(()) => {
-                        self.current_wallpaper = Some(wp.id.clone());
-                        self.last_error = None;
+                        let wp = wp.clone();
+                        self.set_current(&wp);
                         if let Ok(db) = Database::open(&self.paths.db_path()) {
                             let _ = db.mark_used(&wp.id);
                         }
@@ -277,6 +329,7 @@ impl DisplayEngine {
 
         info!(mode = %mode, "display mode changed");
         self.mode = mode;
+        self.emit(DaemonEvent::ModeChanged { mode });
         Ok(())
     }
 
@@ -317,7 +370,7 @@ impl DisplayEngine {
             Some(wp) => {
                 let path = Path::new(&wp.file_path);
                 self.backend.set_wallpaper_all(path).await?;
-                self.current_wallpaper = Some(wp.id.clone());
+                self.set_current(&wp);
                 if let Ok(db) = Database::open(&self.paths.db_path()) {
                     let _ = db.mark_used(&wp.id);
                 }
@@ -355,8 +408,8 @@ impl DisplayEngine {
                 if path.exists() {
                     match self.backend.set_wallpaper_all(path).await {
                         Ok(()) => {
-                            self.current_wallpaper = Some(wp.id.clone());
-                            self.last_error = None;
+                            let wp = wp.clone();
+                            self.set_current(&wp);
                             info!(workspace = workspace_id, id = %wp.id, "workspace wallpaper set");
                         }
                         Err(e) => {
@@ -407,7 +460,7 @@ impl DisplayEngine {
             running: true,
             mode: self.mode,
             paused: self.paused,
-            current_wallpaper: self.current_wallpaper.clone(),
+            current_wallpaper: self.current.as_ref().map(|w| w.id.clone()),
             wallpaper_count: self.wallpapers.len() as u32,
             next_change: self.next_change.map(|t| {
                 let remaining = t.saturating_duration_since(Instant::now());
@@ -452,6 +505,15 @@ mod tests {
             }
         }
 
+        /// Up from the first request, for tests about what an apply does
+        /// rather than about waiting for one.
+        fn ready_now() -> Self {
+            Self {
+                ready_at: 1,
+                probes: AtomicU32::new(1),
+            }
+        }
+
         fn is_up(&self) -> bool {
             self.ready_at != 0 && self.probes.load(Ordering::SeqCst) >= self.ready_at
         }
@@ -485,6 +547,26 @@ mod tests {
         }
     }
 
+    /// Every event the engine has emitted so far, drained without blocking.
+    fn drained(rx: &mut broadcast::Receiver<DaemonEvent>) -> Vec<DaemonEvent> {
+        let mut events = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            events.push(event);
+        }
+        events
+    }
+
+    /// The ids of the wallpapers a run of events says reached the screen.
+    fn changed_ids(events: &[DaemonEvent]) -> Vec<String> {
+        events
+            .iter()
+            .filter_map(|e| match e {
+                DaemonEvent::WallpaperChanged { wallpaper } => Some(wallpaper.id.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
     /// An engine over a throwaway XDG root, holding one wallpaper that exists
     /// on disk. Probing is instant so tests assert behaviour, not timing.
     fn engine_with(backend: FakeBackend) -> (DisplayEngine, tempfile::TempDir) {
@@ -499,7 +581,8 @@ mod tests {
         let file = paths.wallpapers_dir().join("wp1.jpg");
         std::fs::write(&file, b"not really a jpeg").unwrap();
 
-        let mut engine = DisplayEngine::new(Config::default(), paths, Box::new(backend));
+        let (events, _) = broadcast::channel(64);
+        let mut engine = DisplayEngine::new(Config::default(), paths, Box::new(backend), events);
         engine.readiness = ReadinessPolicy {
             attempts: 5,
             initial_delay: Duration::ZERO,
@@ -811,5 +894,110 @@ mod tests {
             status.last_error.is_none(),
             "a stale failure must not outlive the wallpaper that fixed it"
         );
+    }
+
+    #[tokio::test]
+    async fn every_way_the_wallpaper_changes_reaches_a_subscriber() {
+        // The three assignment sites — a rotation, an explicit pick, a
+        // workspace switch — used to write `current` independently. A
+        // subscriber that only hears about one of them is the bug.
+        let (mut engine, _tmp) = engine_with(FakeBackend::ready_now());
+        engine.config.workspaces = vec![muralis_core::config::WorkspaceConfig {
+            workspace: 1,
+            wallpaper: "wp1".into(),
+        }];
+        let mut rx = engine.events.subscribe();
+
+        engine.apply_current().await;
+        engine.set_wallpaper("wp1").await.unwrap();
+        engine.mode = DisplayMode::Workspace;
+        engine.handle_workspace_change(1).await;
+
+        assert_eq!(
+            changed_ids(&drained(&mut rx)),
+            ["wp1", "wp1", "wp1"],
+            "a rotation, a SetWallpaper and a workspace switch must each push"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_failed_apply_tells_nobody_the_wallpaper_changed() {
+        // A Consumer regenerates its whole palette from the image it is told
+        // about; announcing one that never reached the screen is worse than
+        // announcing nothing.
+        let (mut engine, _tmp) = engine_with(FakeBackend::ready_at(0));
+        let mut rx = engine.events.subscribe();
+
+        engine.apply_current().await;
+
+        assert!(drained(&mut rx).is_empty());
+    }
+
+    #[tokio::test]
+    async fn a_successful_pick_clears_a_recorded_failure() {
+        // `set_wallpaper` used to assign `current` without clearing
+        // `last_error`, so a Consumer kept showing a failure the next
+        // successful pick had already fixed.
+        let backend = FakeBackend::ready_at(2);
+        let (mut engine, _tmp) = engine_with(backend);
+        engine.apply_current().await;
+        assert!(engine.status().last_error.is_some());
+
+        engine.backend.is_ready().await.ok();
+        engine.backend.is_ready().await.ok();
+        engine.set_wallpaper("wp1").await.unwrap();
+
+        assert!(engine.status().last_error.is_none());
+    }
+
+    #[tokio::test]
+    async fn a_new_subscriber_is_told_what_is_already_on_screen() {
+        let (mut engine, _tmp) = engine_with(FakeBackend::ready_now());
+        engine.apply_current().await;
+
+        let snapshot = engine.snapshot();
+
+        assert_eq!(
+            changed_ids(&snapshot),
+            ["wp1"],
+            "a Consumer connecting mid-session must not wait for the next rotation"
+        );
+        assert!(snapshot
+            .iter()
+            .any(|e| matches!(e, DaemonEvent::ModeChanged { .. })));
+        assert!(snapshot
+            .iter()
+            .any(|e| matches!(e, DaemonEvent::PauseChanged { paused: false })));
+    }
+
+    #[tokio::test]
+    async fn a_snapshot_with_nothing_applied_says_so_by_omission() {
+        let (engine, _tmp) = engine_with(FakeBackend::ready_at(1));
+
+        let snapshot = engine.snapshot();
+
+        assert!(
+            changed_ids(&snapshot).is_empty(),
+            "nothing has been applied, so there is no wallpaper to announce"
+        );
+        assert_eq!(snapshot.len(), 2, "mode and pause state still come through");
+    }
+
+    #[tokio::test]
+    async fn a_mode_change_is_pushed_but_a_refused_one_is_not() {
+        let (mut engine, _tmp) = engine_with(FakeBackend::ready_at(1));
+        let mut rx = engine.events.subscribe();
+
+        engine.set_mode(DisplayMode::Sequential).unwrap();
+        assert!(engine.set_mode(DisplayMode::Workspace).is_err());
+
+        let events = drained(&mut rx);
+        assert_eq!(events.len(), 1, "only the change that took effect is news");
+        assert!(matches!(
+            events[0],
+            DaemonEvent::ModeChanged {
+                mode: DisplayMode::Sequential
+            }
+        ));
     }
 }

--- a/muralis-daemon/src/display/engine.rs
+++ b/muralis-daemon/src/display/engine.rs
@@ -5,7 +5,7 @@ use tokio::sync::mpsc;
 use tokio::time::{interval, Instant, MissedTickBehavior};
 use tracing::{info, warn};
 
-use muralis_core::backend::WallpaperBackend;
+use muralis_core::backend::{wait_until_ready, ReadinessPolicy, WallpaperBackend};
 use muralis_core::cache;
 use muralis_core::config::Config;
 use muralis_core::db::Database;
@@ -26,6 +26,8 @@ pub struct DisplayEngine {
     current_wallpaper: Option<String>,
     wallpapers: Vec<Wallpaper>,
     next_change: Option<Instant>,
+    last_error: Option<String>,
+    readiness: ReadinessPolicy,
 }
 
 impl DisplayEngine {
@@ -41,6 +43,8 @@ impl DisplayEngine {
             current_wallpaper: None,
             wallpapers: Vec::new(),
             next_change: None,
+            last_error: None,
+            readiness: ReadinessPolicy::default(),
         }
     }
 
@@ -53,7 +57,7 @@ impl DisplayEngine {
 
         // RandomStartup: pick one wallpaper at launch, then behave like Static
         if self.mode == DisplayMode::RandomStartup {
-            self.next().await;
+            self.startup_apply().await;
         }
 
         // initial cache prune
@@ -149,6 +153,28 @@ impl DisplayEngine {
         }
     }
 
+    /// The one-shot `random_startup` apply, gated on the backend's own daemon
+    /// being up. The compositor typically launches muralis and the backend
+    /// together with no sequencing, and this apply is the only one of the
+    /// session — firing it into a socket that is not bound yet means no
+    /// wallpaper until the next login.
+    async fn startup_apply(&mut self) {
+        // Nothing to apply means nothing to wait for — an empty library must
+        // not hold the daemon's startup hostage to an absent backend.
+        if self.wallpapers.is_empty() {
+            return;
+        }
+
+        if let Err(e) = wait_until_ready(self.backend.as_ref(), &self.readiness).await {
+            warn!(backend = self.backend.name(), "backend not ready: {e}");
+            self.last_error = Some(format!("backend not ready: {e}"));
+        }
+
+        // Attempt regardless: the probe is a best-effort gate, not a veto, and
+        // apply_current records its own failure.
+        self.next().await;
+    }
+
     fn reload_wallpapers(&mut self) {
         match Database::open(&self.paths.db_path()) {
             Ok(db) => match db.list_wallpapers() {
@@ -203,15 +229,24 @@ impl DisplayEngine {
                 match self.backend.set_wallpaper_all(path).await {
                     Ok(()) => {
                         self.current_wallpaper = Some(wp.id.clone());
+                        self.last_error = None;
                         if let Ok(db) = Database::open(&self.paths.db_path()) {
                             let _ = db.mark_used(&wp.id);
                         }
                         info!(id = %wp.id, "wallpaper set");
                     }
-                    Err(e) => warn!("failed to set wallpaper: {e}"),
+                    // No retry here: a mid-session failure is followed by a tick
+                    // or a user command soon enough. It is recorded rather than
+                    // only logged, so a Consumer can say the wallpaper on screen
+                    // is not the one muralis thinks it set.
+                    Err(e) => {
+                        warn!("failed to set wallpaper: {e}");
+                        self.last_error = Some(e.to_string());
+                    }
                 }
             } else {
                 warn!(path = %path.display(), "wallpaper file missing");
+                self.last_error = Some(format!("wallpaper file missing: {}", path.display()));
             }
         }
     }
@@ -271,9 +306,13 @@ impl DisplayEngine {
                     match self.backend.set_wallpaper_all(path).await {
                         Ok(()) => {
                             self.current_wallpaper = Some(wp.id.clone());
+                            self.last_error = None;
                             info!(workspace = workspace_id, id = %wp.id, "workspace wallpaper set");
                         }
-                        Err(e) => warn!("failed to set workspace wallpaper: {e}"),
+                        Err(e) => {
+                            warn!("failed to set workspace wallpaper: {e}");
+                            self.last_error = Some(e.to_string());
+                        }
                     }
                 }
             } else {
@@ -324,6 +363,7 @@ impl DisplayEngine {
                 let remaining = t.saturating_duration_since(Instant::now());
                 format!("{}s", remaining.as_secs())
             }),
+            last_error: self.last_error.clone(),
         }
     }
 
@@ -333,5 +373,200 @@ impl DisplayEngine {
         } else {
             self.next_change = None;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use muralis_core::backend::ReadinessPolicy;
+    use muralis_core::error::{MuralisError, Result};
+    use muralis_core::models::SourceType;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    /// Backend that reports ready from the `ready_at`-th probe onward
+    /// (`0` = never) and only then accepts a wallpaper, like awww-daemon.
+    struct FakeBackend {
+        ready_at: u32,
+        probes: AtomicU32,
+    }
+
+    impl FakeBackend {
+        fn ready_at(ready_at: u32) -> Self {
+            Self {
+                ready_at,
+                probes: AtomicU32::new(0),
+            }
+        }
+
+        fn is_up(&self) -> bool {
+            self.ready_at != 0 && self.probes.load(Ordering::SeqCst) >= self.ready_at
+        }
+    }
+
+    #[async_trait]
+    impl WallpaperBackend for FakeBackend {
+        async fn set_wallpaper(&self, _path: &Path, _monitor: &str) -> Result<()> {
+            self.set_wallpaper_all(_path).await
+        }
+
+        async fn set_wallpaper_all(&self, _path: &Path) -> Result<()> {
+            if self.is_up() {
+                Ok(())
+            } else {
+                Err(MuralisError::Backend("socket not bound".into()))
+            }
+        }
+
+        async fn is_ready(&self) -> Result<()> {
+            self.probes.fetch_add(1, Ordering::SeqCst);
+            if self.is_up() {
+                Ok(())
+            } else {
+                Err(MuralisError::Backend("socket not bound".into()))
+            }
+        }
+
+        fn name(&self) -> &str {
+            "fake"
+        }
+    }
+
+    /// An engine over a throwaway XDG root, holding one wallpaper that exists
+    /// on disk. Probing is instant so tests assert behaviour, not timing.
+    fn engine_with(backend: FakeBackend) -> (DisplayEngine, tempfile::TempDir) {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = MuralisPaths {
+            config_dir: tmp.path().join("config"),
+            data_dir: tmp.path().join("data"),
+            cache_dir: tmp.path().join("cache"),
+        };
+        paths.ensure_dirs().unwrap();
+
+        let file = paths.wallpapers_dir().join("wp1.jpg");
+        std::fs::write(&file, b"not really a jpeg").unwrap();
+
+        let mut engine = DisplayEngine::new(Config::default(), paths, Box::new(backend));
+        engine.readiness = ReadinessPolicy {
+            attempts: 5,
+            initial_delay: Duration::ZERO,
+            max_delay: Duration::ZERO,
+        };
+        engine.wallpapers = vec![Wallpaper {
+            id: "wp1".into(),
+            source_type: SourceType::new("test"),
+            source_id: "wp1".into(),
+            source_url: None,
+            width: 5120,
+            height: 1440,
+            tags: Vec::new(),
+            file_path: file.to_string_lossy().into_owned(),
+            added_at: "2026-09-10T00:00:00Z".into(),
+            last_used: None,
+            use_count: 0,
+        }];
+
+        (engine, tmp)
+    }
+
+    #[tokio::test]
+    async fn failed_apply_is_visible_in_status() {
+        let (mut engine, _tmp) = engine_with(FakeBackend::ready_at(0));
+
+        engine.apply_current().await;
+
+        let status = engine.status();
+        assert!(
+            status.current_wallpaper.is_none(),
+            "nothing was applied, so nothing is current"
+        );
+        assert!(
+            status
+                .last_error
+                .as_deref()
+                .is_some_and(|e| e.contains("socket not bound")),
+            "the backend failure should reach status, got: {:?}",
+            status.last_error
+        );
+    }
+
+    #[tokio::test]
+    async fn startup_waits_for_a_backend_that_is_still_coming_up() {
+        let (mut engine, _tmp) = engine_with(FakeBackend::ready_at(3));
+        engine.mode = DisplayMode::RandomStartup;
+
+        engine.startup_apply().await;
+
+        let status = engine.status();
+        assert_eq!(
+            status.current_wallpaper.as_deref(),
+            Some("wp1"),
+            "the startup apply must survive losing the race with the backend daemon"
+        );
+        assert!(status.last_error.is_none());
+    }
+
+    #[tokio::test]
+    async fn startup_against_an_absent_backend_says_so_instead_of_going_quiet() {
+        let (mut engine, _tmp) = engine_with(FakeBackend::ready_at(0));
+        engine.mode = DisplayMode::RandomStartup;
+
+        engine.startup_apply().await;
+
+        let status = engine.status();
+        assert!(status.current_wallpaper.is_none());
+        assert!(
+            status.last_error.is_some(),
+            "a lost startup must be reportable, not only a warn! nobody reads"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_empty_library_does_not_wait_on_the_backend() {
+        let (mut engine, _tmp) = engine_with(FakeBackend::ready_at(0));
+        engine.mode = DisplayMode::RandomStartup;
+        engine.wallpapers.clear();
+
+        engine.startup_apply().await;
+
+        assert!(
+            engine.status().last_error.is_none(),
+            "with nothing to apply there is nothing to wait for, and no failure to report"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_failed_workspace_switch_is_reported_like_any_other() {
+        let (mut engine, _tmp) = engine_with(FakeBackend::ready_at(0));
+        engine.mode = DisplayMode::Workspace;
+        engine.config.workspaces = vec![muralis_core::config::WorkspaceConfig {
+            workspace: 1,
+            wallpaper: "wp1".into(),
+        }];
+
+        engine.handle_workspace_change(1).await;
+
+        assert!(engine.status().current_wallpaper.is_none());
+        assert!(engine.status().last_error.is_some());
+    }
+
+    #[tokio::test]
+    async fn a_later_success_clears_the_recorded_failure() {
+        let backend = FakeBackend::ready_at(2);
+        let (mut engine, _tmp) = engine_with(backend);
+
+        // first apply happens before any probe, so the backend is still down
+        engine.apply_current().await;
+        assert!(engine.status().last_error.is_some());
+
+        engine.startup_apply().await;
+
+        let status = engine.status();
+        assert_eq!(status.current_wallpaper.as_deref(), Some("wp1"));
+        assert!(
+            status.last_error.is_none(),
+            "a stale failure must not outlive the wallpaper that fixed it"
+        );
     }
 }

--- a/muralis-daemon/src/display/mod.rs
+++ b/muralis-daemon/src/display/mod.rs
@@ -18,6 +18,7 @@ pub enum DaemonCommand {
     },
     SetMode {
         mode: DisplayMode,
+        respond: oneshot::Sender<Result<(), String>>,
     },
     Pause,
     Resume,

--- a/muralis-daemon/src/display/mod.rs
+++ b/muralis-daemon/src/display/mod.rs
@@ -3,7 +3,7 @@ pub mod scheduler;
 
 use tokio::sync::oneshot;
 
-use muralis_core::ipc::DaemonStatus;
+use muralis_core::ipc::{DaemonStatus, FavoritesPage};
 use muralis_core::models::DisplayMode;
 
 pub enum DaemonCommand {
@@ -12,6 +12,11 @@ pub enum DaemonCommand {
     },
     Next,
     Prev,
+    Favorites {
+        offset: Option<u32>,
+        limit: Option<u32>,
+        respond: oneshot::Sender<Result<FavoritesPage, String>>,
+    },
     SetWallpaper {
         id: String,
         respond: oneshot::Sender<Result<(), String>>,

--- a/muralis-daemon/src/display/mod.rs
+++ b/muralis-daemon/src/display/mod.rs
@@ -3,7 +3,7 @@ pub mod scheduler;
 
 use tokio::sync::oneshot;
 
-use muralis_core::ipc::{DaemonStatus, FavoritesPage};
+use muralis_core::ipc::{DaemonEvent, DaemonStatus, FavoritesPage};
 use muralis_core::models::DisplayMode;
 
 pub enum DaemonCommand {
@@ -12,6 +12,13 @@ pub enum DaemonCommand {
     },
     Next,
     Prev,
+    /// The daemon's current state rendered as events, for a **Consumer** that
+    /// just opened a subscription. Without it a subscriber learns nothing until
+    /// the next rotation, and a reconnect after a `DankSocket` backoff would
+    /// silently miss whatever changed while it was away.
+    Snapshot {
+        respond: oneshot::Sender<Vec<DaemonEvent>>,
+    },
     Favorites {
         offset: Option<u32>,
         limit: Option<u32>,

--- a/muralis-daemon/src/ipc.rs
+++ b/muralis-daemon/src/ipc.rs
@@ -119,8 +119,19 @@ async fn dispatch_request(
             }
         }
         IpcRequest::SetMode { mode } => {
-            let _ = cmd_tx.send(DaemonCommand::SetMode { mode }).await;
-            IpcResponse::ok()
+            let (tx, rx) = oneshot::channel();
+            if cmd_tx
+                .send(DaemonCommand::SetMode { mode, respond: tx })
+                .await
+                .is_err()
+            {
+                return IpcResponse::error("engine unavailable");
+            }
+            match rx.await {
+                Ok(Ok(())) => IpcResponse::ok(),
+                Ok(Err(msg)) => IpcResponse::error(msg),
+                Err(_) => IpcResponse::error("engine dropped response"),
+            }
         }
         IpcRequest::Pause => {
             let _ = cmd_tx.send(DaemonCommand::Pause).await;

--- a/muralis-daemon/src/ipc.rs
+++ b/muralis-daemon/src/ipc.rs
@@ -1,15 +1,16 @@
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixListener;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{broadcast, mpsc, oneshot};
 use tracing::{info, warn};
 
-use muralis_core::ipc::{IpcRequest, IpcResponse};
+use muralis_core::ipc::{DaemonEvent, IpcRequest, IpcResponse};
 use muralis_core::paths::MuralisPaths;
 
 use crate::display::DaemonCommand;
 
 pub async fn serve_ipc(
     cmd_tx: mpsc::Sender<DaemonCommand>,
+    events: broadcast::Sender<DaemonEvent>,
     mut shutdown: tokio::sync::watch::Receiver<bool>,
 ) -> anyhow::Result<()> {
     let socket_path = MuralisPaths::socket_path();
@@ -28,8 +29,10 @@ pub async fn serve_ipc(
                 match result {
                     Ok((stream, _)) => {
                         let tx = cmd_tx.clone();
+                        let events = events.clone();
+                        let shutdown = shutdown.clone();
                         tokio::spawn(async move {
-                            if let Err(e) = handle_connection(stream, tx).await {
+                            if let Err(e) = handle_connection(stream, tx, events, shutdown).await {
                                 warn!("IPC connection error: {e}");
                             }
                         });
@@ -49,8 +52,16 @@ pub async fn serve_ipc(
 async fn handle_connection(
     stream: tokio::net::UnixStream,
     cmd_tx: mpsc::Sender<DaemonCommand>,
+    events: broadcast::Sender<DaemonEvent>,
+    shutdown: tokio::sync::watch::Receiver<bool>,
 ) -> anyhow::Result<()> {
     let (reader, mut writer) = stream.into_split();
+    // Subscribe before the request has even been read. An event fired between
+    // parsing `subscribe` and subscribing would land in the gap between the
+    // snapshot and the stream and be lost for good; subscribing first can only
+    // duplicate an event the snapshot also carries, and a Consumer re-applying
+    // the wallpaper it already has is harmless where missing one is not.
+    let event_rx = events.subscribe();
     let mut buf_reader = BufReader::new(reader);
     let mut line = String::new();
     buf_reader.read_line(&mut line).await?;
@@ -66,12 +77,98 @@ async fn handle_connection(
         }
     };
 
+    // The one request that is not request/response: it keeps the connection
+    // and writes events until the Consumer goes away.
+    if matches!(request, IpcRequest::Subscribe) {
+        return stream_events(writer, event_rx, &cmd_tx, shutdown).await;
+    }
+
     let response = dispatch_request(request, &cmd_tx).await;
 
     let mut resp_line = serde_json::to_string(&response)?;
     resp_line.push('\n');
     writer.write_all(resp_line.as_bytes()).await?;
     Ok(())
+}
+
+/// Serve one **subscription**: a snapshot of daemon state as events, then
+/// every event the engine emits from here on.
+///
+/// A write that fails is the Consumer having hung up — the ordinary end of a
+/// subscription, not an error worth logging.
+async fn stream_events(
+    mut writer: tokio::net::unix::OwnedWriteHalf,
+    mut event_rx: broadcast::Receiver<DaemonEvent>,
+    cmd_tx: &mpsc::Sender<DaemonCommand>,
+    mut shutdown: tokio::sync::watch::Receiver<bool>,
+) -> anyhow::Result<()> {
+    info!("subscriber connected");
+    if !write_snapshot(&mut writer, cmd_tx).await? {
+        return Ok(());
+    }
+
+    loop {
+        tokio::select! {
+            received = event_rx.recv() => match received {
+                Ok(event) => {
+                    if !write_event(&mut writer, &event).await? {
+                        break;
+                    }
+                }
+                // The subscriber fell far enough behind that the channel
+                // dropped events on its behalf. Its view is now stale in ways
+                // it cannot know, so resend the snapshot rather than carry on
+                // from a gap.
+                Err(broadcast::error::RecvError::Lagged(missed)) => {
+                    warn!(missed, "subscriber fell behind; resyncing");
+                    if !write_snapshot(&mut writer, cmd_tx).await? {
+                        break;
+                    }
+                }
+                Err(broadcast::error::RecvError::Closed) => break,
+            },
+            _ = shutdown.changed() => break,
+        }
+    }
+
+    info!("subscriber disconnected");
+    Ok(())
+}
+
+/// Ask the engine for its current state and write it out as events. `false`
+/// means the connection is gone (or the engine is), and the caller should stop.
+async fn write_snapshot(
+    writer: &mut tokio::net::unix::OwnedWriteHalf,
+    cmd_tx: &mpsc::Sender<DaemonCommand>,
+) -> anyhow::Result<bool> {
+    let (tx, rx) = oneshot::channel();
+    if cmd_tx
+        .send(DaemonCommand::Snapshot { respond: tx })
+        .await
+        .is_err()
+    {
+        return Ok(false);
+    }
+    let Ok(snapshot) = rx.await else {
+        return Ok(false);
+    };
+
+    for event in snapshot {
+        if !write_event(writer, &event).await? {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+/// One newline-terminated JSON event. `false` means the peer is gone.
+async fn write_event(
+    writer: &mut tokio::net::unix::OwnedWriteHalf,
+    event: &DaemonEvent,
+) -> anyhow::Result<bool> {
+    let mut line = serde_json::to_string(event)?;
+    line.push('\n');
+    Ok(writer.write_all(line.as_bytes()).await.is_ok())
 }
 
 async fn dispatch_request(
@@ -166,6 +263,9 @@ async fn dispatch_request(
             let _ = cmd_tx.send(DaemonCommand::Reload).await;
             IpcResponse::ok()
         }
+        // Handled by `handle_connection` before dispatch: it is the one
+        // request that never produces a response.
+        IpcRequest::Subscribe => IpcResponse::error("subscribe is a streaming request"),
         IpcRequest::Quit => {
             let _ = cmd_tx.send(DaemonCommand::Quit).await;
             IpcResponse::ok()
@@ -177,6 +277,7 @@ async fn dispatch_request(
 mod tests {
     use super::*;
     use muralis_core::ipc::FavoritesPage;
+    use muralis_core::models::{SourceType, Wallpaper};
 
     /// Drives one request through the dispatcher against a stand-in engine that
     /// answers `Favorites` with a fixed page.
@@ -213,6 +314,161 @@ mod tests {
         assert_eq!(
             page.offset, 16,
             "the window the Consumer asked for comes back"
+        );
+    }
+
+    fn a_wallpaper(id: &str) -> Wallpaper {
+        Wallpaper {
+            id: id.into(),
+            source_type: SourceType::new("test"),
+            source_id: id.into(),
+            source_url: None,
+            width: 5120,
+            height: 1440,
+            tags: Vec::new(),
+            file_path: format!("/tmp/{id}.jpg"),
+            added_at: "2026-09-10T00:00:00Z".into(),
+            last_used: None,
+            use_count: 0,
+        }
+    }
+
+    /// A stand-in engine whose snapshot is one wallpaper plus its mode and
+    /// pause state, like the real one's.
+    fn engine_answering_snapshot() -> mpsc::Sender<DaemonCommand> {
+        let (cmd_tx, mut cmd_rx) = mpsc::channel(4);
+        tokio::spawn(async move {
+            while let Some(cmd) = cmd_rx.recv().await {
+                if let DaemonCommand::Snapshot { respond } = cmd {
+                    let _ = respond.send(vec![
+                        DaemonEvent::WallpaperChanged {
+                            wallpaper: Box::new(a_wallpaper("on-screen")),
+                        },
+                        DaemonEvent::ModeChanged {
+                            mode: muralis_core::models::DisplayMode::Random,
+                        },
+                        DaemonEvent::PauseChanged { paused: false },
+                    ]);
+                }
+            }
+        });
+        cmd_tx
+    }
+
+    /// Serves one `subscribe` connection and hands back the client's read half.
+    async fn subscribed(
+        events: broadcast::Sender<DaemonEvent>,
+        shutdown: tokio::sync::watch::Receiver<bool>,
+    ) -> BufReader<tokio::net::unix::OwnedReadHalf> {
+        let (client, server) = tokio::net::UnixStream::pair().unwrap();
+        let cmd_tx = engine_answering_snapshot();
+        tokio::spawn(async move {
+            handle_connection(server, cmd_tx, events, shutdown)
+                .await
+                .unwrap();
+        });
+
+        let (reader, mut writer) = client.into_split();
+        writer
+            .write_all(b"{\"command\":\"subscribe\"}\n")
+            .await
+            .unwrap();
+        BufReader::new(reader)
+    }
+
+    async fn next_event(reader: &mut BufReader<tokio::net::unix::OwnedReadHalf>) -> DaemonEvent {
+        let mut line = String::new();
+        reader.read_line(&mut line).await.unwrap();
+        serde_json::from_str(line.trim()).unwrap_or_else(|e| panic!("not an event: {line:?} ({e})"))
+    }
+
+    #[tokio::test]
+    async fn a_subscriber_is_caught_up_before_it_is_streamed_to() {
+        let (events, _) = broadcast::channel(16);
+        let (_shutdown_tx, shutdown) = tokio::sync::watch::channel(false);
+        let mut reader = subscribed(events.clone(), shutdown).await;
+
+        // The snapshot, in full, before anything new happens.
+        assert!(matches!(
+            next_event(&mut reader).await,
+            DaemonEvent::WallpaperChanged { wallpaper } if wallpaper.id == "on-screen"
+        ));
+        assert!(matches!(
+            next_event(&mut reader).await,
+            DaemonEvent::ModeChanged { .. }
+        ));
+        assert!(matches!(
+            next_event(&mut reader).await,
+            DaemonEvent::PauseChanged { paused: false }
+        ));
+
+        // Then the same connection carries what the engine does next — this is
+        // the framing change: no shutdown(), no second connection.
+        events
+            .send(DaemonEvent::WallpaperChanged {
+                wallpaper: Box::new(a_wallpaper("rotated-to")),
+            })
+            .unwrap();
+        events
+            .send(DaemonEvent::PauseChanged { paused: true })
+            .unwrap();
+
+        assert!(matches!(
+            next_event(&mut reader).await,
+            DaemonEvent::WallpaperChanged { wallpaper } if wallpaper.id == "rotated-to"
+        ));
+        assert!(matches!(
+            next_event(&mut reader).await,
+            DaemonEvent::PauseChanged { paused: true }
+        ));
+    }
+
+    #[tokio::test]
+    async fn a_one_shot_command_still_gets_one_line_and_a_close() {
+        // Holding subscriptions open must not have changed the shape every
+        // script and keybind depends on.
+        let (client, server) = tokio::net::UnixStream::pair().unwrap();
+        let (events, _) = broadcast::channel(16);
+        let (_shutdown_tx, shutdown) = tokio::sync::watch::channel(false);
+        let cmd_tx = engine_answering_snapshot();
+        tokio::spawn(async move {
+            handle_connection(server, cmd_tx, events, shutdown)
+                .await
+                .unwrap();
+        });
+
+        let (reader, mut writer) = client.into_split();
+        writer.write_all(b"{\"command\":\"next\"}\n").await.unwrap();
+
+        let mut reader = BufReader::new(reader);
+        let mut line = String::new();
+        reader.read_line(&mut line).await.unwrap();
+        assert_eq!(line.trim(), r#"{"status":"ok"}"#);
+
+        line.clear();
+        assert_eq!(
+            reader.read_line(&mut line).await.unwrap(),
+            0,
+            "the daemon hangs up after one response"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_daemon_shutting_down_ends_the_subscription() {
+        let (events, _) = broadcast::channel(16);
+        let (shutdown_tx, shutdown) = tokio::sync::watch::channel(false);
+        let mut reader = subscribed(events, shutdown).await;
+        for _ in 0..3 {
+            next_event(&mut reader).await;
+        }
+
+        shutdown_tx.send(true).unwrap();
+
+        let mut line = String::new();
+        assert_eq!(
+            reader.read_line(&mut line).await.unwrap(),
+            0,
+            "a subscriber must see the socket close, not hang on a dead daemon"
         );
     }
 }

--- a/muralis-daemon/src/ipc.rs
+++ b/muralis-daemon/src/ipc.rs
@@ -103,6 +103,27 @@ async fn dispatch_request(
             let _ = cmd_tx.send(DaemonCommand::Prev).await;
             IpcResponse::ok()
         }
+        IpcRequest::Favorites { offset, limit } => {
+            let (tx, rx) = oneshot::channel();
+            if cmd_tx
+                .send(DaemonCommand::Favorites {
+                    offset,
+                    limit,
+                    respond: tx,
+                })
+                .await
+                .is_err()
+            {
+                return IpcResponse::error("engine unavailable");
+            }
+            match rx.await {
+                Ok(Ok(page)) => {
+                    IpcResponse::ok_with_data(serde_json::to_value(page).unwrap_or_default())
+                }
+                Ok(Err(msg)) => IpcResponse::error(msg),
+                Err(_) => IpcResponse::error("engine dropped response"),
+            }
+        }
         IpcRequest::SetWallpaper { id } => {
             let (tx, rx) = oneshot::channel();
             if cmd_tx
@@ -149,5 +170,49 @@ async fn dispatch_request(
             let _ = cmd_tx.send(DaemonCommand::Quit).await;
             IpcResponse::ok()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use muralis_core::ipc::FavoritesPage;
+
+    /// Drives one request through the dispatcher against a stand-in engine that
+    /// answers `Favorites` with a fixed page.
+    async fn dispatch_line(line: &str) -> IpcResponse {
+        let (cmd_tx, mut cmd_rx) = mpsc::channel(1);
+        tokio::spawn(async move {
+            while let Some(cmd) = cmd_rx.recv().await {
+                if let DaemonCommand::Favorites {
+                    offset, respond, ..
+                } = cmd
+                {
+                    let _ = respond.send(Ok(FavoritesPage {
+                        wallpapers: Vec::new(),
+                        total: 7,
+                        offset: offset.unwrap_or(0),
+                    }));
+                }
+            }
+        });
+        let request: IpcRequest = serde_json::from_str(line).unwrap();
+        dispatch_request(request, &cmd_tx).await
+    }
+
+    #[tokio::test]
+    async fn favorites_answers_a_page_on_the_wire() {
+        let resp = dispatch_line(r#"{"command":"favorites","offset":16,"limit":16}"#).await;
+
+        let data = match resp {
+            IpcResponse::Ok { data: Some(data) } => data,
+            other => panic!("expected a served page, got {other:?}"),
+        };
+        let page: FavoritesPage = serde_json::from_value(data).unwrap();
+        assert_eq!(page.total, 7);
+        assert_eq!(
+            page.offset, 16,
+            "the window the Consumer asked for comes back"
+        );
     }
 }

--- a/muralis-daemon/src/ipc.rs
+++ b/muralis-daemon/src/ipc.rs
@@ -1,20 +1,23 @@
+use std::path::PathBuf;
+
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixListener;
 use tokio::sync::{broadcast, mpsc, oneshot};
 use tracing::{info, warn};
 
 use muralis_core::ipc::{DaemonEvent, IpcRequest, IpcResponse};
-use muralis_core::paths::MuralisPaths;
 
 use crate::display::DaemonCommand;
 
+/// Serve the daemon socket until `shutdown` says otherwise, then take the
+/// socket file with it. The path is passed in rather than looked up so a test
+/// can serve somewhere other than the one socket a machine has.
 pub async fn serve_ipc(
+    socket_path: PathBuf,
     cmd_tx: mpsc::Sender<DaemonCommand>,
     events: broadcast::Sender<DaemonEvent>,
     mut shutdown: tokio::sync::watch::Receiver<bool>,
 ) -> anyhow::Result<()> {
-    let socket_path = MuralisPaths::socket_path();
-
     // clean up stale socket
     if socket_path.exists() {
         std::fs::remove_file(&socket_path)?;
@@ -470,5 +473,66 @@ mod tests {
             0,
             "a subscriber must see the socket close, not hang on a dead daemon"
         );
+    }
+
+    /// Serves on the given path until the returned switch is flipped.
+    fn serving_at(
+        socket_path: &std::path::Path,
+    ) -> (
+        tokio::sync::watch::Sender<bool>,
+        tokio::task::JoinHandle<anyhow::Result<()>>,
+    ) {
+        // Nothing dials in these tests, so the command receiver is never read.
+        let (cmd_tx, _cmd_rx) = mpsc::channel(4);
+        let (events, _) = broadcast::channel(4);
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let path = socket_path.to_path_buf();
+        let handle =
+            tokio::spawn(async move { serve_ipc(path, cmd_tx, events, shutdown_rx).await });
+        (shutdown_tx, handle)
+    }
+
+    async fn await_socket(socket_path: &std::path::Path) {
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while !socket_path.exists() {
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("the socket should have been bound");
+    }
+
+    #[tokio::test]
+    async fn shutting_down_takes_the_socket_file_with_it() {
+        // A socket left behind answers a Consumer's dial with "connection
+        // refused" rather than "nothing there" — the daemon is gone either
+        // way, and only one of those is what happened.
+        let tmp = tempfile::tempdir().unwrap();
+        let socket_path = tmp.path().join("muralis.sock");
+        let (shutdown_tx, handle) = serving_at(&socket_path);
+        await_socket(&socket_path).await;
+
+        shutdown_tx.send(true).unwrap();
+        handle.await.unwrap().unwrap();
+
+        assert!(
+            !socket_path.exists(),
+            "a daemon that shut down cleanly must not leave its socket behind"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_socket_left_by_a_previous_daemon_does_not_block_the_next_one() {
+        // Whatever killed the last daemon — SIGKILL, a panic, a power cut —
+        // the next one still binds. That is what keeps this bug mild.
+        let tmp = tempfile::tempdir().unwrap();
+        let socket_path = tmp.path().join("muralis.sock");
+        std::fs::write(&socket_path, b"not a socket at all").unwrap();
+
+        let (shutdown_tx, handle) = serving_at(&socket_path);
+        await_socket(&socket_path).await;
+
+        shutdown_tx.send(true).unwrap();
+        handle.await.unwrap().unwrap();
     }
 }

--- a/muralis-daemon/src/main.rs
+++ b/muralis-daemon/src/main.rs
@@ -2,7 +2,7 @@ mod display;
 mod ipc;
 mod workspace;
 
-use tokio::sync::{mpsc, watch};
+use tokio::sync::{broadcast, mpsc, watch};
 use tracing::info;
 
 use muralis_core::backend::create_backend;
@@ -29,6 +29,10 @@ async fn main() -> anyhow::Result<()> {
 
     let backend = create_backend(&config);
     let (cmd_tx, cmd_rx) = mpsc::channel(32);
+    // Wallpaper changes are rare and subscribers few; the buffer only has to
+    // absorb a burst while a Consumer is busy repainting. One that falls
+    // further behind than this is resynced from a snapshot, not disconnected.
+    let (event_tx, _) = broadcast::channel(64);
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
     // spawn workspace listener
@@ -40,14 +44,15 @@ async fn main() -> anyhow::Result<()> {
     // spawn IPC server
     let ipc_shutdown = shutdown_rx.clone();
     let ipc_tx = cmd_tx.clone();
+    let ipc_events = event_tx.clone();
     tokio::spawn(async move {
-        if let Err(e) = ipc::serve_ipc(ipc_tx, ipc_shutdown).await {
+        if let Err(e) = ipc::serve_ipc(ipc_tx, ipc_events, ipc_shutdown).await {
             tracing::error!("IPC server error: {e}");
         }
     });
 
     // spawn display engine
-    let engine = DisplayEngine::new(config, paths.clone(), backend);
+    let engine = DisplayEngine::new(config, paths.clone(), backend, event_tx);
     let engine_shutdown = shutdown_rx.clone();
     let engine_handle = tokio::spawn(async move {
         engine.run(cmd_rx, engine_shutdown).await;

--- a/muralis-daemon/src/main.rs
+++ b/muralis-daemon/src/main.rs
@@ -27,6 +27,7 @@ async fn main() -> anyhow::Result<()> {
     let config = Config::load_or_default(&paths);
     info!(backend = %config.general.backend, mode = %config.display.mode, "starting muralis-daemon");
 
+    let socket_path = MuralisPaths::socket_path();
     let backend = create_backend(&config);
     let (cmd_tx, cmd_rx) = mpsc::channel(32);
     // Wallpaper changes are rare and subscribers few; the buffer only has to
@@ -45,8 +46,9 @@ async fn main() -> anyhow::Result<()> {
     let ipc_shutdown = shutdown_rx.clone();
     let ipc_tx = cmd_tx.clone();
     let ipc_events = event_tx.clone();
+    let ipc_socket = socket_path.clone();
     tokio::spawn(async move {
-        if let Err(e) = ipc::serve_ipc(ipc_tx, ipc_events, ipc_shutdown).await {
+        if let Err(e) = ipc::serve_ipc(ipc_socket, ipc_tx, ipc_events, ipc_shutdown).await {
             tracing::error!("IPC server error: {e}");
         }
     });
@@ -59,19 +61,40 @@ async fn main() -> anyhow::Result<()> {
     });
 
     // wait for shutdown signal
-    tokio::signal::ctrl_c().await?;
-    info!("received ctrl+c, shutting down");
+    let signal = shutdown_signal().await?;
+    info!(signal, "shutting down");
     let _ = shutdown_tx.send(true);
 
     // wait for engine to finish
     let _ = engine_handle.await;
 
-    // clean up socket
-    let socket = MuralisPaths::socket_path();
-    if socket.exists() {
-        let _ = std::fs::remove_file(socket);
+    // Belt and braces: serve_ipc unlinks the socket on the same signal, but
+    // it may have died before ever getting there.
+    if socket_path.exists() {
+        let _ = std::fs::remove_file(&socket_path);
     }
 
     info!("muralis-daemon stopped");
     Ok(())
+}
+
+/// Wait for a signal that means stop, and say which one arrived.
+///
+/// Answering only ctrl+c meant every ordinary shutdown skipped both cleanup
+/// paths: Hyprland's `exec-once` children get SIGTERM at session end, as would
+/// anything under systemd, so the socket outlived every logout. It also matters
+/// more since subscriptions landed — the watch channel this drives is what ends
+/// an open **Subscription** in an orderly way, rather than by process death.
+async fn shutdown_signal() -> anyhow::Result<&'static str> {
+    use tokio::signal::unix::{signal, SignalKind};
+
+    let mut terminate = signal(SignalKind::terminate())?;
+
+    tokio::select! {
+        result = tokio::signal::ctrl_c() => {
+            result?;
+            Ok("interrupt")
+        }
+        _ = terminate.recv() => Ok("terminate"),
+    }
 }


### PR DESCRIPTION
Everything the **DMS Widget** needs, and the widget itself. The daemon could not push, so a timed rotation left DankMaterialShell's matugen palette matching a wallpaper that was no longer on screen — this branch closes that, and the protocol gaps behind it.

## The Consumer seam

[ADR 0001](docs/adr/0001-cli-transport-for-consumers.md) had Consumers spawn the CLI per action. It rested on a false premise — DMS's QML *does* speak raw sockets, through `DankSocket` — so [ADR 0002](docs/adr/0002-consumers-speak-the-daemon-socket.md) reverses it: a Consumer connects to `/tmp/muralis-$UID.sock` and speaks the **IPC contract** directly. What was actually load-bearing in 0001 was a missing protocol feature, not a transport choice, so the branch adds it rather than routing around it.

That left three gaps, each now closed:

- **`Favorites { offset, limit }`** (#10) — the Library over the socket, answered from the database rather than the engine's rotation cache, because `favorites add` writes the store behind the daemon's back.
- **`available_modes`** (#14) — the modes this config can actually run, so a switcher greys out the two that would silently stop the wallpaper changing.
- **`Subscribe`** (#9) — a held-open connection streaming tagged events, opening with a snapshot. [ADR 0003](docs/adr/0003-subscriptions-open-with-a-snapshot.md) records why the payload is a whole `Wallpaper` row and why the snapshot is required rather than nice: without it a reconnect after a `DankSocket` backoff would permanently miss whatever changed while away.

## The daemon

- **#11** — `random_startup` applies exactly once, so losing the startup race with the backend cost the whole session's wallpaper. The daemon now probes with bounded backoff before that one apply, and a failure that still happens reaches `status` as `last_error` instead of a `warn!` nobody reads.
- **#13 / #12** — `SetMode` refuses a mode whose config precondition is missing, and writes the choice through to `config.toml` before it takes effect, so the running mode and the one the next daemon boots into cannot disagree. The edit is surgical; hand-written comments survive.
- **#16** — the daemon answered ctrl+c and nothing else, so SIGTERM skipped both cleanup paths and every logout left a stale socket. It now answers the signal a supervisor actually sends.
- `current_wallpaper` became `current: Option<Wallpaper>`, written only by `set_current()`. Three independent writes to the field defining "what is on screen" was a bug magnet, and one of them never cleared `last_error`.

## The widget (#15)

`dms-widget/` — a DankBar pill and a popout over the Library: 16 thumbnails a page, click-to-set, transport, mode chips. Two sockets, because the contract has two shapes: one `Subscribe` held open for the session, and one-shot commands that dial per request since the daemon hangs up after answering. `SessionData.setWallpaper()` is guarded on the path actually differing — every redial replays the snapshot, and regenerating a palette we already have is pure cost.

All three renderable failure states are drawn rather than hidden: daemon down, nothing applied this session, empty library.

## Verification

`cargo test` 150 tests, `clippy --workspace --all-targets -D warnings` clean. Beyond that, the parts tests cannot reach were measured against running processes:

- the subscription, on the real socket: snapshot on connect, live events for rotate/pause/mode, fan-out to three subscribers each with their own snapshot, clean close on daemon exit
- the widget, type-checked against the DMS 1.6.1 QML tree and then installed in a live DMS for a human to judge
- SIGTERM cleanup, against the built binary in a private mount namespace: exit 143 with the socket left behind before, exit 0 with it gone after

## Note for the release

The widget needs a daemon carrying `Subscribe`. Packaged 0.2.4 predates it and will reject the request, so `dms-widget` shipping and a muralis release have to land together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01APpFgK5KNd2xKsygCZ7sZF
